### PR TITLE
Version 2.6.7 (faster on runs after 1st) 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,10 +40,8 @@ env:
     - VerboseVar=-v
     - BadFilesVar=-b
     - ExcludedVar=-g
-# Tail $TAIL_LINES for output logging    
-    - TAIL_LINES=20
-# Sleep time between first and second run    
-    - WAIT_TIME=2
+    - TAIL_LINES=20  # Tail $TAIL_LINES for output logging
+    - WAIT_TIME=2    # Sleep time between first and second run    
 # Delete !!!!!!!!!!!!!!!!!!! CAREFULL !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 # To ensure an empty Flckr database. Set DeleteAllFromFlickr=1. 0 otherwise.
     - DeleteAllFromFlickr=0
@@ -62,7 +60,7 @@ env:
 # Replace
     #- TestScenario=Replace UploadrOptions="$VerboseVar $BadFilesVar"
 # RemoveReplace
-    - TestScenario=RemoveReplace UploadrOptions="$VerboseVar $BadFilesVar -p 5"
+    - TestScenario=RemoveReplace UploadrOptions="$VerboseVar $BadFilesVar -p 10"
 # ExcludedFolders
     - TestScenario=ExcludedFolders UploadrOptions="$VerboseVar $BadFilesVar $ExcludedVar -p 5"
 # =============================================================================
@@ -76,7 +74,6 @@ before_script:
   - echo $pythonVersion
 #  - ls -laR
   - cp tests/uploadr.ini .
-# cp uploadr.ini to python/bin folder (use python version) to run pytest --doctest-modules
   - cp tests/uploadr.ini /home/travis/virtualenv/python$pythonVersion/bin/uploadr.ini
   - grep FILES_DIR uploadr.ini
 #  - cat uploadr.ini
@@ -98,7 +95,6 @@ script:
   - if [[ $TRAVIS_PYTHON_VERSION == 2* && $DeleteAllFromFlickr == 1 ]]; then coverage run -a --concurrency multiprocessing ./flickr-deletr-master/delete.py; fi
 
 # First RUN -------------------------------------------------------------------
-#  - coverage run -a --concurrency multiprocessing uploadr.py $VerboseVar -p 2
   - coverage run -a --concurrency multiprocessing uploadr.py $VerboseVar $UploadrOptions > /home/travis/build/oPromessa/flickr-uploader/nohup.log 2> /home/travis/build/oPromessa/flickr-uploader/nohup.err
   - tail -$TAIL_LINES /home/travis/build/oPromessa/flickr-uploader/nohup.log
   - tail -$TAIL_LINES /home/travis/build/oPromessa/flickr-uploader/nohup.err
@@ -149,7 +145,7 @@ script:
 
 after_script:
 # MD5SUM Output for REFERENCE -------------------------------------------------
-  - if [[ $TestScenario == RemoveReplace ]]; then find "./tests/Test Photo Library" -type f -exec md5sum '{}' \; ; fi
+#  - if [[ $TestScenario == RemoveReplace ]]; then find "./tests/Test Photo Library" -type f -exec md5sum '{}' \; ; fi
 
 # DB OUTPUT for REFERENCE -----------------------------------------------------
   - sqlite3 flickrdb "SELECT *, datetime( last_modified, 'unixepoch', 'localtime') FROM files;"

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,10 +59,10 @@ env:
     #- TestScenario=Remove UploadrOptions="$VerboseVar $BadFilesVar"
 # Replace
     #- TestScenario=Replace UploadrOptions="$VerboseVar $BadFilesVar"
-# RemoveReplace
-    - TestScenario=RemoveReplace UploadrOptions="$VerboseVar $BadFilesVar -p 10"
-# ExcludedFolders
-    - TestScenario=ExcludedFolders UploadrOptions="$VerboseVar $BadFilesVar $ExcludedVar -p 5"
+# RemoveReplace, also test cleaning up badfiles database entries
+    - TestScenario=RemoveReplace UploadrOptions="$VerboseVar $BadFilesVar -p 10 -c"
+# ExcludedFolders, also test cleaning up badfiles database entries
+    - TestScenario=ExcludedFolders UploadrOptions="$VerboseVar $BadFilesVar $ExcludedVar -p 5 -c"
 # =============================================================================
 # before_script
 # Get database token ready

--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ optional arguments:
    - Adjust the run schedule settings, the email notifications
    - Under "Run Command" include a reference to the uploadr.cron file
 `/full/path/to/uploadr.cron`
-- Use  upload.cron added to the distribution and adapt to your needs.
+- Use sample file uploadr.cron added to the distribution and adapt to your needs.
 - Do not use crontab directly. Having Task Scheduler replaces crontab.
 
 ### On Linux/Unix/Mac based systems, run via crontab
@@ -243,6 +243,7 @@ optional arguments:
 ### Launch from the command line in Daemon mode (-d option).
 - Recommendation is to use Task Scheduler or cron.
 - With -d option it runs in daemon mode and checks for files every SLEEP_TIME seconds (as configured on uploadr.ini)
+- It simply loads the files. It does not create Albums/Sets.
 - SLEEP_TIME is only used in this case.
 ```bash
 $ ./uploadr.py -v -d

--- a/README.md
+++ b/README.md
@@ -35,6 +35,39 @@ THIS SCRIPT IS PROVIDED WITH NO WARRANTY WHATSOEVER.
 PLEASE REVIEW THE SOURCE CODE TO MAKE SURE IT WILL WORK FOR YOUR NEEDS.
 IF YOU FIND A BUG, PLEASE REPORT IT.
 
+### Sample file structure
+Consider this example to explain how files are uploaded into Albums/Sets on Flickr.
+
+If you have the following folders and pics  (the name of the flickr setnames/Albums depends on the uploadr.ini file setting FULL_SET_NAME, but I normally use it as False):
+```
+/home/user/media/pic00.jpg
+/home/user/media/Album1/pic01.jpg
+/home/user/media/Album2/pic02.jpg
+/home/user/media/Album3/pic03.jpg
+/home/user/media/folder/Album4/pic04.jpg
+/home/user/media/folder/Album4/Sub/pic041.jpg
+/home/user/media/newfolder/Album4/pic042.jpg
+/home/user/media/folderAlbum5/pic01.jpg
+
+```
+
+And you setup FILES_DIR
+```
+FILES_DIR=/home/user/media
+```
+You should get the following:
+
+| FilePathName | SetName/Album Name (with FULL_SET_NAME=False) | SetName/Album Name (with FULL_SET_NAME=True) | Pic | Remarks | 
+| ------------- | ------------- | ------------- | ------------- | ------------- |
+| /home/user/media/pic00.jpg | media | . | pic00 | |
+| /home/user/media/Album1/pic01.jpg | Album1 |  Album1 | pic01 | |
+| /home/user/media/Album2/pic02.jpg | Album2 |  Album2 | pic02 | |
+| /home/user/media/Album3/pic03.jpg | Album3 |  Album3 | pic03 | |
+| /home/user/media/folder/Album4/pic04.jpg | Album4 | folder/Album4 | pic04 | |
+| /home/user/media/folder/Album4/Sub/pic041.jpg | Sub  | folder/Album4/Sub  | pic041 | |
+| /home/user/media/newfolder/Album4/pic042.jpg | Album4 | newfolder/Album4 | pic042 | |
+| /home/user/media/Album5/pic01.jpg | Album5 |  Album5 | pic01 | It's the same pic as in Album01 but it will be loaded twice as it belongs to a different Album |
+
 ## Requirements
 ---------------
 * Python 2.7+ (should work on DSM from Synology (v6.1), Windows and MAC)
@@ -227,21 +260,52 @@ Inspired by:
 You may use this code however you see fit in any form whatsoever.
 And enjoy!!!
 
-## Q&A
-------
+## Questions & Answers
+----------------------
 * Q: Who is this script designed for?
-* A: Those people comfortable with the command line that want to backup their media on Flickr in full resolution.
+   - Those people comfortable with the command line that want to backup their media on Flickr in full resolution.
 
 * Q: Why don't you use OAuth?
-* A: I do! As of November 2017
+   - I do! As of November 2017
 
 * Q: Are you a python ninja?
-* A: No, sorry. I just picked up the language to write this script because python can easily be installed on a Synology Diskstation.
+   - No, sorry. I just picked up the language to write this script because python can easily be installed on a Synology Diskstation.
 
 * Q: Is this script feature complete and fully tested?
-* A: Nope. It's a work in progress. I've tested it as needed for my needs, but it's possible to build additional features by contributing to the script.
+   - Nope. It's a work in progress. I've tested it as needed for my needs, but it's possible to build additional features by contributing to the script.
 
 * Q: How to automate it with a Synology NAS ?
-* A: First you will need to run script at least one time in a ssh client to get the token file.
+   - First you will need to run script at least one time in a ssh client to get the token file.
      Refer to the "Task Scheduler (cron)" section above.
      Then with DSM 6.1, create an automate task, make it run once a day for example, and put this in the textbox without quotes "path_to_your_python_program path_to_your_script". For example, assuming you installed Python package from Synocommunity, command should look like "/usr/local/python/bin/python /volume1/script/flickr-uploader/uploadr.py".
+
+* Q: What if I have different folders to sync?
+   - the standard mode of operation should be to sync always the same main folder structure with all your subfolder/pics.
+   - syncing different folders on each run *does work* and uploads new pics; but uploadr was not originally designed for that. 
+      - What happens to previously loaded pics depends if they still exist and Uploadr can still find them (depending if FILES_DIR was set as an absolute folder or relative folder path)
+         - File to upload: /home/user/media/2014/05/05/photo.jpg
+         - FULL_SET_NAME:
+            - False: 05
+            - True: 2014/05/05
+   - Uploadr saves the (full or relative depending on FILES_DIR) path name for the pics loaded. So, event though you provide a new origin folder, if the previously loaded pics still exist on their original locations, they are not deleted. If they are deleted from such original location or uploadr has no access to them, then they will be deleted from flickr.
+   - If using relative FILES_DIR and two files exist on the same subfolder, it will not be re-uploaded.
+   - So, in a nutshell, too many issues if you play around changing the FILES_DIR location.
+
+
+* Q: "my understanding is that this is a sync script, which means when I later delete a pic from a synced folder, it will get deleted from Flickr"
+   - Yes a file removed locally will be deleted from Flickr.
+   - *Remark*: I'm assuming in between each run you keep the contents of the flickrdb control database and do not remove it.
+
+* Q: "What about previously existing folders (they didn't seem to get deleted)"
+   - If all files from a folder (and corresponding Album on flickr) are deleted, then the actual Album will be also eliminated. Again, if you do not chnage the FILES_DIR in between runs.
+
+* Q: What about when I sync a folder with the same name of a previously existing folder? (you mention
+getting existing sets from Flickr is managed also
+   - hmmm... if you mean "sync a folder" via setting FILES_DIR... it would depend if you use full or relative pathname on FILES_DIR. Check the section "Clarification" above. It will delete the files he cannot find locally.
+   - hmmm... if you mean two subfolders with the same name, to which Set/Album will be added depends on the setting FULL_SET_NAME. Check the section "Clarification" above for example pic042.
+
+* Q: What about when I run the script on ~/pictures/parent_folder/folder_A and then later on ~/pictures/parentfolder will the script recongize the folder_A within parentfolder as being the one it uploaded before becaues its content will have matching checksums?
+   - Again it depends on FULL_SET_NAME setting and FILE_DIR being an absolute or relative path and the match is initially done by full pathname + filename. So, in your example ~/pictures will expand to a full path so it would recognize the same files and not upload them again.
+
+* Q: I thought I read a mention of checksum as a way to detect file modification: what about the same file in 2 different folders, is it then upoad each time (in a set with the folder name) or only once?
+   - same file on two folders loads up twice. Check example above with Album5/pic02.jpg

--- a/uploadr.py
+++ b/uploadr.py
@@ -222,7 +222,7 @@ class UPLDRConstants:
     TimeFormat = '%Y.%m.%d %H:%M:%S'
     # For future use...
     # UTF = 'utf-8'
-    Version = '2.6.6'
+    Version = '2.6.7'
     # Identify the execution Run of this process
     Run = eval(time.strftime('int("%j")+int("%H")*100+int("%M")'))
 

--- a/uploadr.py
+++ b/uploadr.py
@@ -1256,7 +1256,7 @@ class Uploadr:
                 # Will release (set to None) the nulockDB lock control
                 # this prevents subsequent calls to useDBLock( nuLockDB, False)
                 # to raise exception:
-                #    ValueError('semaphore or lock released too many times
+                #    ValueError('semaphore or lock released too many times')
                 if (args.verbose):
                     niceprint('===Multiprocessing=== pool joined! '
                               'What happens to nulockDB is None:[{!s}]? '

--- a/uploadr.py
+++ b/uploadr.py
@@ -1189,8 +1189,8 @@ class Uploadr:
                     logging.warning('===Actual/Planned Chunk size: '
                                     '[{!s}]/[{!s}]'
                                     .format(len(nuChangeMedia), sz))
-                    logging.debug(type(nuChangeMedia))
-
+                    logging.debug('===type(nuChangeMedia)=[{!s}]'
+                                  .format(type(nuChangeMedia)))
                     logging.debug('===Job/Task Process: Creating...')
                     uploadTask = multiprocessing.Process(
                                         target=self.uploadFileX,
@@ -4050,7 +4050,7 @@ if __name__ == "__main__":
         # Will run in daemon mode every SLEEP_TIME seconds
         logging.warning('Will run in daemon mode every {!s} seconds'
                         .format(SLEEP_TIME))
-        logging.WARNING('Make sure you have previously authenticated!')
+        logging.warning('Make sure you have previously authenticated!')
         flick.run()
     else:
         niceprint("Checking if token is available... if not will authenticate")

--- a/uploadr.py
+++ b/uploadr.py
@@ -850,6 +850,9 @@ class Uploadr:
                 niceprint('\t{!s} files processed (uploaded, md5ed '
                           'or timestamp checked)'.format(count))
 
+        sys.stdout.flush()
+
+
     # -------------------------------------------------------------------------
     # authenticate
     #

--- a/uploadr.py
+++ b/uploadr.py
@@ -1735,7 +1735,7 @@ class Uploadr:
 
             # use file modified timestamp to check for changes
             last_modified = os.stat(file).st_mtime
-            file_checksum = self.md5Checksum(file)
+            file_checksum = None
 
             # Check if file is already loaded
             if (args.not_is_already_uploaded):
@@ -1743,6 +1743,7 @@ class Uploadr:
                 logging.warning('not_is_photo_already_uploaded:[{!s}] '
                                 .format(isLoaded))                
             else:
+                file_checksum = self.md5Checksum(file)
                 isLoaded, isCount, isfile_id = self.is_photo_already_uploaded(
                                                                 file,
                                                                 file_checksum,
@@ -1754,6 +1755,9 @@ class Uploadr:
                                         isfile_id, row is None))
 
             if isLoaded and row is None:
+                if file_checksum is None:
+                    file_checksum = self.md5Checksum(file)
+
                 # Insert into DB files
                 logging.warning('ALREADY LOADED. '
                                 'DO NOT PERFORM ANYTHING ELSE. '
@@ -1775,6 +1779,9 @@ class Uploadr:
                                 'On Album:[{!s}]...'
                                 .format(StrUnicodeOut(file),
                                         StrUnicodeOut(setName)))
+
+                if file_checksum is None:
+                    file_checksum = self.md5Checksum(file)
 
                 # Title Handling
                 if args.title:  # Replace
@@ -2071,10 +2078,11 @@ class Uploadr:
                         # Update db both the new file/md5 and the
                         # last_modified time of file by by calling replacePhoto
 
-                        fileMd5 = self.md5Checksum(file)
-                        if (fileMd5 != str(row[4])):
+                        if file_checksum is None:
+                            file_checksum = self.md5Checksum(file)
+                        if (file_checksum != str(row[4])):
                             self.replacePhoto(lock, file, row[1], row[4],
-                                              fileMd5, last_modified,
+                                              file_checksum, last_modified,
                                               cur, con)
                 except lite.Error as e:
                     reportError(Caught=True,

--- a/uploadr.py
+++ b/uploadr.py
@@ -31,8 +31,6 @@
       INFO: relevant output of variables
       DEBUG: entering and existing functions
 
-    * CHANGE -s OPTION TO SET IF ONE SHOULD SEARCH PRIOR TO LOADING...As it may
-      take a long time! Need to check. Maybe not!
     * Test deleted file from local which is also deleted from flickr
     * Change code to insert on database prior to upload and then update result
     * Protect all DB access( single processing or multiprocessing) with:
@@ -1737,14 +1735,21 @@ class Uploadr:
             file_checksum = self.md5Checksum(file)
 
             # Check if file is already loaded
-            isLoaded, isCount, isfile_id = self.is_photo_already_uploaded(
-                                                               file,
-                                                               file_checksum,
-                                                               setName)
-            logging.warning('is_photo_already_uploaded:[{!s}] '
-                            'count:[{!s}] pic:[{!s}] '
-                            'row is None == [{!s}]'
-                            .format(isLoaded, isCount, isfile_id, row is None))
+            if (args.not_is_already_uploaded):
+                isLoaded = False
+                logging.warning('not_is_photo_already_uploaded:[{!s}] '
+                                .format(isLoaded))                
+            else:
+                isLoaded, isCount, isfile_id = self.is_photo_already_uploaded(
+                                                                file,
+                                                                file_checksum,
+                                                                setName)
+                logging.warning('is_photo_already_uploaded:[{!s}] '
+                                'count:[{!s}] pic:[{!s}] '
+                                'row is None == [{!s}]'
+                                .format(isLoaded, isCount,
+                                        isfile_id, row is None))
+
             if isLoaded and row is None:
                 # Insert into DB files
                 logging.warning('ALREADY LOADED. '
@@ -1857,17 +1862,17 @@ class Uploadr:
 
                             # Save photo_id returned from Flickr upload
                             photo_id = uploadResp.findall('photoid')[0].text
-                            logging.warning('Uploaded photo_id=[{!s}] [{!s}] '
+                            logging.warning('Uploaded [{!s}] photo_id=[{!s}] '
                                             'Ok. Will check for issues ('
                                             'duplicates or wrong checksum)'
-                                            .format(photo_id,
-                                                    StrUnicodeOut(file)))
+                                            .format(StrUnicodeOut(file),
+                                                    photo_id))
                             if (args.verbose):
-                                niceprint('Uploaded photo_id=[{!s}] [{!s}] '
+                                niceprint('Uploaded [{!s}] photo_id=[{!s}] '
                                           'Ok. Will check for issues ('
                                           'duplicates or wrong checksum)'
-                                          .format(photo_id,
-                                                  StrUnicodeOut(file)))
+                                          .format(StrUnicodeOut(file),
+                                                  photo_id))                                
 
                             # Successful upload. Break attempts cycle
                             break
@@ -3944,6 +3949,9 @@ if __name__ == "__main__":
                         help='Provides progress indicator on each upload. '
                              'Normally used in conjunction with -v option. '
                              'See also LOGGING_LEVEL value in INI file.')
+    parser.add_argument('-u', '--not-is-already-uploaded', action='store_true',
+                        help='Do not check if file is already uploaded '
+                             'and exists on flickr prior to uploading.')
     parser.add_argument('-n', '--dry-run', action='store_true',
                         help='Dry run.')
     parser.add_argument('-i', '--title', action='store',
@@ -3992,7 +4000,7 @@ if __name__ == "__main__":
                              'files in your Library that flickr does not '
                              'recognize (Error 5). Check also option -b. ')
     # finds duplicated images (based on checksum, titlename, setName) in Flickr
-    parser.add_argument('-s', '--search-for-duplicates', action='store_true',
+    parser.add_argument('-z', '--search-for-duplicates', action='store_true',
                         help='Lists duplicated files: same checksum, '
                              'same title, list SetName (if different). '
                              'Not operational at this time.')


### PR DESCRIPTION
- Optimize calling md5Cecksum which results in huge gains in runs after the 1st one.
- README updated with further clarifications explanation on file structure and loading/replace/delete logic and more FAQs
- flush on printing progress information when in paralell processing to ensure ordered output.
- Enhancement #33: New option -u --not-is-already-uploaded to disable checking if file is already actually loaded on flickr
