### PR TITLE
V2.7.6 Enhanced configuration mechanism. Improved UploadFile function. New setup.py (optional)

### DIFF
--- a/lib/__version__.py
+++ b/lib/__version__.py
@@ -5,6 +5,6 @@
     __version__ = Semantic Versioning number Major.Minor.Patch
                   Check https://semver.org
 """
-VERSION = (2, 7, 5)
+VERSION = (2, 7, 6)
 
 __version__ = '.'.join(map(str, VERSION))

--- a/uploadr.ini
+++ b/uploadr.ini
@@ -36,22 +36,22 @@ DRIP_TIME = 1 * 60
 ################################################################################
 #   File we keep the history of uploaded files in.
 ################################################################################
-DB_PATH = os.path.join(os.getcwd(), "flickrdb")
+DB_PATH = os.path.join(os.path.dirname(sys.argv[0]), "flickrdb")
 
 ################################################################################
 #   Location of file where we keep the lock for multiple running processes from happening
 ################################################################################
-LOCK_PATH = os.path.join(os.getcwd(), ".flickrlock")
+LOCK_PATH = os.path.join(os.path.dirname(sys.argv[0]), ".flickrlock")
 
 ################################################################################
 #   File we keep the flickr authentication information.
 ################################################################################
-TOKEN_CACHE = os.path.join(os.getcwd(), "token")
+TOKEN_CACHE = os.path.join(os.path.dirname(sys.argv[0]), "token")
 
 ################################################################################
 #   Location of file where we keep the tokenfile
 ################################################################################
-TOKEN_PATH = os.path.join(os.getcwd(), ".flickrToken")
+TOKEN_PATH = os.path.join(os.path.dirname(sys.argv[0]), ".flickrToken")
 
 ################################################################################
 #   List of folder names you don't want to parse

--- a/uploadr.py
+++ b/uploadr.py
@@ -4570,32 +4570,25 @@ if __name__ == "__main__":
             reportError(Caught=True,
                         CaughtPrefix='+++ ',
                         CaughtCode='601',
-                        CaughtMsg='Exiting.',
+                        CaughtMsg='Invalid -C parameter INI file. '
+                                  'Exiting...',
                         NicePrint=True)
             sys.exit(2)
     else:
-        # sys.prefix
+        # sys.argv[0]
+        UPLDRConstants.baseDir = os.path.dirname(sys.argv[0])
+        UPLDRConstants.INIfile = os.path.join(UPLDRConstants.baseDir,
+                                              "uploadr.ini")
+
         if not checkBaseDir_INIfile(UPLDRConstants.baseDir,
                                     UPLDRConstants.INIfile):
             reportError(Caught=True,
                         CaughtPrefix='+++ ',
                         CaughtCode='602',
-                        CaughtMsg='Invalid sys.prefix INI file. '
-                                  'Trying current working directory.',
+                        CaughtMsg='Invalid sys.argv INI file. '
+                                  'Exiting...',
                         NicePrint=True)
-            # cwd
-            UPLDRConstants.baseDir = os.getcwd()
-            UPLDRConstants.INIfile = os.path.join(UPLDRConstants.baseDir,
-                                                  "uploadr.ini")
-            if not checkBaseDir_INIfile(UPLDRConstants.baseDir,
-                                        UPLDRConstants.INIfile):
-                reportError(Caught=True,
-                            CaughtPrefix='+++ ',
-                            CaughtCode='603',
-                            CaughtMsg='Invalid current directory INI file'
-                                      'Exiting...',
-                            NicePrint=True)
-                sys.exit(2)
+            sys.exit(2)
 
     # Source configuration from INIfile
     xCfg.readconfig(UPLDRConstants.INIfile, ['Config'])


### PR DESCRIPTION
## Fixes/Features
- Enhancement #7 apply further control on INI parameters. New configuration mechanism. Default values are included in the app. Ignores wrong values in INI file. Except for *api_key* and *secret* which you have to adjust, all others are preset.
- Enhancement #28 Revise upload sequence.
- More clear output messages on execution progress.
- Setup (**optional**):
   - You can run install with `python3 setup.py install --prefix=~/apps/Python`
- From v2.7.6 `uploadr.ini` configuration is searched from:
   -  `--config-file` argument
   - from the sys.argv[0] path (compatible with previsous versions)

## Questions & Answers
- **Note that uploadr.ini definition for path search** of DB_PATH, LOCK_PATH, TOKEN_CACHE and TOKEN_PATH still uses sys.argv[0] location as a basis.
- (to be) Updated installation notes on Readme.

## Output Messages
- More clear output messages on excution progress.

## Environment and Coding
- Python 2.7 + 3.6 compatibility: use of "# noqa" as applicable
- autopep8, PEP8, flakes adjustments
- pytest --flakes & pytest --doctest-modules
- Runs several unittests
- Created setup.py (**optional**)