### PR TITLE
V2.8.5 Features: authentication, rotating, FlickrAPI wrapper module, setup. Under the hood improvements/refactoring. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ flickrdb
 *.pyc
 dist
 flickr_uploader.egg-info/*
+**logs

--- a/.travis.yml
+++ b/.travis.yml
@@ -88,7 +88,7 @@ env:
     - TestScenario=MultiProcessing UploadrOptions="$VerboseVar $BadFilesVar -p 30"
 # addAlbumsMigrate. Option --add-albums-migrate is added on SECOND RUN. No badfiles handling
     - TestScenario=addAlbumsMigrate UploadrOptions="$VerboseVar -p 30"
-# RemoveReplace, Multiprocessing. Also test cleaning up badfiles database entries
+# RemoveReplace, Multiprocessing, Clean BadFiles, ListPhotosNotInSet
     - TestScenario=RemoveReplace UploadrOptions="$VerboseVar $BadFilesVar $ListPhotosNotInSet -p 10 -c"
 # ExcludedFolders+IgnoredFiles in Single Processing mode.
 # Also test cleaning up badfiles database entries and listing files not in set.

--- a/README.md
+++ b/README.md
@@ -84,15 +84,16 @@ Might work on other platforms like Windows also.
 *Side note:* don't be overwhelmed with this setup. They are quite straitghtforward.
 Summary steps:
 
-1. Enable SSH access to Synology DSM Server
+1. Enable SSH access to Synology DSM Server. (Optionally) install Python 3.
 2. Prepare a local folder location for Python modules install
 3. Download and install pip
 4. Download and install flickrapi
 5. Download and install flickr-uploader
 
-### 1.Enable SSH access to Synology DSM Server
+### 1.Enable SSH access to Synology DSM Server. (Optionally) install Python 3.
 Enable and access your Synology DSM via SSH with an admin user.
 Avoid the use of root for security reasons.
+(Optionally) install via the Synology DSM Packages the "Python 3" package (corresponds to version 3.5)
 
 ### 2. Prepare a local folder location for Python modules install.
 **This avoids messing up with the system files.**
@@ -102,6 +103,10 @@ $ cd
 $ mkdir apps
 $ mkdir apps/Python
 $ export PYTHONPATH=~/apps/Python/lib/python2.7/site-packages
+```
+Or, for Python 3.5:
+``` bash
+$ export PYTHONPATH=~/apps/Python/lib/python3.5/site-packages
 ```
 Create also a 'dev' directory/folder. Download here the files/packages prior to intstallation:
 ```bash
@@ -118,6 +123,10 @@ Follow [these guidelines for PIP installation](https://pip.pypa.io/en/latest/ins
 ```bash
 $ cd
 $ cd dev
+dev$ curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
+  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
+                                 Dload  Upload   Total   Spent    Left  Speed
+100 1603k  100 1603k    0     0  3828k      0 --:--:-- --:--:-- --:--:-- 3827k
 dev$ python get-pip.py --prefix=~/apps/Python
 Collecting pip
     Downloading pip-9.0.1-py2.py3-none-any.whl (1.3MB)
@@ -131,14 +140,38 @@ Collecting wheel
 Installing collected packages: pip, setuptools, wheel
     Successfully installed pip setuptools wheel
 ```
-### 4. Download and install flickrapi (2.4.0 or 2.3.1)
-**Download** flickrapi-2.3.tar.gz from [PyPi.Python.Org](https://pypi.python.org/pypi/flickrapi).
+### 4. Download and install flickrapi (2.4.0)
 
-**Extract to** ~/dev and run `python setup.py install --prefix=~/apps/Python`
+#### 4.1 OPTION A: With pip
+
+```bash
+$ cd
+$ cd dev
+dev$ export PYTHONPATH=~/apps/Python/lib/python2.7/site-packages
+dev$ pip install flickrapi --prefix=~/apps/Python
+```
+
+#### 4.2 OPTION B: Mannually
+
+**Download** flickrapi-2.4.tar.gz from [PyPi.Python.Org](https://pypi.python.org/pypi/flickrapi).
+
+**Extract to** ~/dev and run `python setup.py install --prefix=~/apps/Python
 
 **Make sure to use the --prefix parameter**
 ```bash
-$ python setup.py install --prefix=~/apps/Python
+$ cd dev
+dev$ wget https://files.pythonhosted.org/packages/b1/f1/d10fa0872e4f781c2ed47e94e728ecd3c1998f8c8d12e78c7329a25d0727/flickrapi-2.4.0.tar.gz
+dev$ tar tzvf flickrapi-2.4.0.tar.gz
+flickrapi-2.4.0/
+flickrapi-2.4.0/CHANGELOG.md
+flickrapi-2.4.0/MANIFEST.in
+flickrapi-2.4.0/.coveragerc
+flickrapi-2.4.0/LICENSE.txt
+flickrapi-2.4.0/tox.ini
+flickrapi-2.4.0/README.md
+(...)
+dev$ cd flickrapi-2.4.0
+dev/flickrapi-2.4.0$ python setup.py install --prefix=~/apps/Python
 python setup.py install --prefix=~/apps/Python
 running install
 running bdist_egg
@@ -151,8 +184,8 @@ Moving chardet-3.0.4-py2.7.egg to /xxx/xxx/xxx/apps/Python/lib/python2.7/site-pa
 Adding chardet 3.0.4 to easy-install.pth file
 Installing chardetect script to /xxx/xxx/xxx/apps/Python/bin
 
-Installed /xxx/xxx/xxx/apps/Python/lib/python2.7/site-packages/chardet-3.0.4-py2.7.egg
-Finished processing dependencies for flickrapi==2.3
+Installed /xxxx/xxx/xxx/apps/Python/lib/python3.5/site-packages/certifi-2018.4.16-py3.5.egg
+Finished processing dependencies for flickrapi==2.4.0
 ```
 
 ###  5. Download and install flickr-uploader
@@ -166,6 +199,16 @@ Extract the contents of the elected tar file.
 * You can then run it from the current folder.
 * Edit the uploadr.ini as appropriate (check Configuration section)
 
+```bash
+$ cd
+$ cd dev
+dev$ wget https://github.com/oPromessa/flickr-uploader/releases/download/2.8.1/flickr-uploader-2.8.1.tar.gz
+dev$ tar xzvf flickr-uploader-2.8.1.tar.gz
+dev$ cd flickr-uploader-2.8.1
+dev/flickr-uploader-2.8.1$ python3.5 setup.py install --prefix=~/apps/Python/
+dev/flickr-uploader-2.8.1$ python3.5 setup.py installcfg --folder ~/apps
+
+ 
 ## Configuration
 ----------------
 Go to http://www.flickr.com/services/apps/create/apply and apply for an API
@@ -200,10 +243,11 @@ $  export PYTHONPATH=~/apps/Python/lib/python2.7/site-packages
 ```
 
 - On the **first run** you need to authenticate the applicaiton against Flickr.
+   - use the `-a` option
    - uploadr.py will provide you a URL/link which you need to run
 ```bash
 $ cd dev
-dev$ uploadr.py 
+dev$ uploadr.py -a
 Importing xml.etree.ElementTree...done. Continuing.
 --------- (V2.7.7) Init:  ---------
 Python version on this system: 3.6.3 (default, Oct  3 2017, 21:45:48) 
@@ -240,14 +284,10 @@ $ ./uploadr.py --dry-run
 ```
 Run `./uploadrd.py --help` for up to the minute information on arguments:
 ```bash
-Importing xml.etree.ElementTree...done. Continuing.
---------- (V2.7.7) Init:  ---------
-Python version on this system: 3.6.3 (default, Oct  3 2017, 21:45:48) 
-[GCC 7.2.0]
-[2930][2018.04.16 23:47:54]:[12706      ][PRINT   ]:[uploadr] --------- (V2.7.7) Start time: 2018.04.16 23:47:54 ---------(Log:40)
-usage: uploadr.py [-h] [-C filename.ini] [-v] [-x] [-n] [-i TITLE]
-                  [-e DESCRIPTION] [-t TAGS] [-l N] [-z] [-r] [-p P] [-u] [-d]
-                  [-b] [-c] [-s] [-g] [--add-albums-migrate]
+[2601][2018.05.20 22:25:11]:[19737      ][PRINT   ]:[uploadr] ----------- (V2.8.5) Start -----------(Log:40)
+usage: uploadr.py [-h] [-C filename.ini] [-a] [-v] [-x] [-n] [-i TITLE]
+                  [-e DESCRIPTION] [-t TAGS] [-l N] [-r] [-p P] [-u] [-d] [-b]
+                  [-c] [-s] [-g] [--add-albums-migrate]
 
 Upload files to Flickr. Uses uploadr.ini as config file.
 
@@ -256,8 +296,10 @@ optional arguments:
 
 Configuration related options:
   -C filename.ini, --config-file filename.ini
-                        Optional configuration file. Default is:
-                        [/home/ruler/uploader/etc/uploadr.ini]
+                        Optional configuration file. Default
+                        is:[./uploadr.ini]
+  -a, --authenticate    Performs/Verifies authentication with Flickr. To be
+                        run on initial setup.Does not run any other option.
 
 Verbose and dry-run options:
   -v, --verbose         Provides some more verbose output. See also -x option.
@@ -279,23 +321,21 @@ Information options:
   -t TAGS, --tags TAGS  Space-separated tags for uploaded files. It appends to
                         the tags defined in INI file.
   -l N, --list-photos-not-in-set N
-                        List as many as N photos not in set. Maximum listed
-                        photos is 500.
-  -z, --search-for-duplicates
-                        Lists duplicated files: same checksum, same title,
-                        list SetName (if different). Not operational at this
-                        time.
+                        List as many as N photos (with tags) not in set.
+                        Maximum listed photos is 500.
 
 Processing related options:
   -r, --drip-feed       Wait a bit between uploading individual files.
-  -p P, --processes P   Number of photos to upload simultaneously.
+  -p P, --processes P   Number of photos to upload simultaneously. Number of
+                        process to assign pics to sets.
   -u, --not-is-already-uploaded
                         Do not check if file is already uploaded and exists on
                         flickr prior to uploading. Use this option for faster
                         INITIAL upload. Do not use it in subsequent uploads to
                         prevent/recover orphan pics without a set.
   -d, --daemon          Run forever as a daemon.Uploading every SLEEP_TIME
-                        seconds. Please note it only performs upload/replace.
+                        seconds. Please note it only performs upload/raw
+                        convert/replace.
 
 Handling bad and excluded files:
   -b, --bad-files       Save on database bad files to prevent continuous

--- a/lib/FlickrApiWrapper.py
+++ b/lib/FlickrApiWrapper.py
@@ -184,14 +184,15 @@ def flickrapi_fn(fn_name,
 #
 def nu_authenticate(api_key,
                     secret,
-                    token_cache_location):
+                    token_cache_location,
+                    perms='delete'):
     """ nu_authenticate
 
         Authenticate user so we can upload files.
         Assumes the cached token is not available or valid.
-    
+
         api_key, secret, token_cache_location, perms
-    
+
         Returns an instance object for the class flickrapi
     """
 
@@ -248,10 +249,10 @@ def nu_authenticate(api_key,
 
     # Show url. Copy and paste it in your browser
     # Adjust parameter "perms" to to your needs
-    authorize_url = flickrobj.auth_url(perms=u'delete')
+    authorize_url = flickrobj.auth_url(perms=perms)
     print('Copy and paste following authorizaiton URL '
           'in your browser to obtain Verifier Code.')
-    print(authorize_url)
+    print(NPR.strunicodeout(authorize_url))
 
     # Prompt for verifier code from the user.
     # Python 2.7 and 3.6

--- a/lib/FlickrApiWrapper.py
+++ b/lib/FlickrApiWrapper.py
@@ -26,9 +26,7 @@ try:
 except ImportError:
     import http.client as httplib  # Python 3
 import xml
-# Avoids error on some systems:
-#    AttributeError: 'module' object has no attribute 'etree'
-#    on logging.info(xml.etree.ElementTree.tostring(...
+# Prevents error "AttributeError: 'module' object has no attribute 'etree'"
 try:
     DUMMYXML = xml.etree.ElementTree.tostring(
         xml.etree.ElementTree.Element('xml.etree'),

--- a/lib/FlickrApiWrapper.py
+++ b/lib/FlickrApiWrapper.py
@@ -54,7 +54,6 @@ import lib.rate_limited as rate_limited
 # -----------------------------------------------------------------------------
 NPR = NicePrint.NicePrint()
 niceerror = NPR.niceerror
-retry = rate_limited.retry
 
 
 # -----------------------------------------------------------------------------
@@ -94,7 +93,9 @@ def flickrapi_fn(fn_name,
             fn_errcode = error reported by flickrapi exception
     """
 
-    @retry(attempts=attempts, waittime=waittime, randtime=randtime)
+    @rate_limited.retry(attempts=attempts,
+                        waittime=waittime,
+                        randtime=randtime)
     def retry_flickrapi_fn(kwargs):
         """ retry_flickrapi_fn
 

--- a/lib/FlickrApiWrapper.py
+++ b/lib/FlickrApiWrapper.py
@@ -68,8 +68,9 @@ def is_good(res):
         Check res is not None and res.attrib['stat'] == "ok" for XML object
     """
     return False\
-           if res is None\
-           else (not res == "" and res.attrib['stat'] == "ok")
+    if res is None\
+    else (not res == "" and res.attrib['stat'] == "ok")
+
 
 # -----------------------------------------------------------------------------
 def flickrapi_fn(fn_name,

--- a/lib/FlickrApiWrapper.py
+++ b/lib/FlickrApiWrapper.py
@@ -58,12 +58,12 @@ retry = rate_limited.retry
 
 
 # -----------------------------------------------------------------------------
-# isGood
+# is_good
 #
 # Checks if res.attrib['stat'] == "ok"
 #
-def isGood(res):
-    """ isGood
+def is_good(res):
+    """ is_good
 
         Check res is not None and res.attrib['stat'] == "ok" for XML object
     """
@@ -83,7 +83,7 @@ def flickrapi_fn(fn_name,
 
         Runs flickrapi fn_name function handing over **fn_kwargs.
         It retries attempts, waittime, randtime with @retry
-        Checks results isGood and provides feedback accordingly.
+        Checks results is_good and provides feedback accordingly.
         Captures flicrkapi or BasicException error situations.
         caughtcode to report on exception error.
 
@@ -152,7 +152,7 @@ def flickrapi_fn(fn_name,
     finally:
         pass
 
-    if isGood(fn_result):
+    if is_good(fn_result):
         fn_success = True
 
         logging.info('fn:[%s] Output for fn_result:',
@@ -162,11 +162,11 @@ def flickrapi_fn(fn_name,
             encoding='utf-8',
             method='xml'))
     else:
-        logging.error('fn:[%s] isGood(fn_result):[%s]',
+        logging.error('fn:[%s] is_good(fn_result):[%s]',
                       fn_name.__name__,
                       'None'
                       if fn_result is None
-                      else isGood(fn_result))
+                      else is_good(fn_result))
         fn_result = None
 
     logging.info('fn:[%s] success:[%s] result:[%s] errcode:[%s]',

--- a/lib/FlickrApiWrapper.py
+++ b/lib/FlickrApiWrapper.py
@@ -74,6 +74,7 @@ def isGood(res):
     else:
         return False
 
+    return False if res is None else (not res == "" and res.attrib['stat'] == "ok")
 
 # -----------------------------------------------------------------------------
 def flickrapi_fn(fn_name,
@@ -411,12 +412,12 @@ if __name__ == "__main__":
 
     if FLICKR is not None:
         NPR.niceprint('-----------------------------------Number of Photos...')
-        get_success, get_result, get_errcode = flickrapi_fn(
+        GET_SUCCESS, GET_RESULT, GET_ERRCODE = flickrapi_fn(
             FLICKR.people.getPhotos,
             (),
             dict(user_id="me", per_page=1),
             2, 10, True)
 
-        if get_success and get_errcode == 0:
+        if GET_SUCCESS and GET_ERRCODE == 0:
             NPR.niceprint('Number of Photos=[{!s}]'
                           .format(get_result.find('photos').attrib['total']))

--- a/lib/FlickrApiWrapper.py
+++ b/lib/FlickrApiWrapper.py
@@ -68,8 +68,8 @@ def is_good(res):
         Check res is not None and res.attrib['stat'] == "ok" for XML object
     """
     return False\
-    if res is None\
-    else (not res == "" and res.attrib['stat'] == "ok")
+        if res is None\
+        else (not res == "" and res.attrib['stat'] == "ok")
 
 
 # -----------------------------------------------------------------------------

--- a/lib/FlickrApiWrapper.py
+++ b/lib/FlickrApiWrapper.py
@@ -369,6 +369,7 @@ def get_cached_token(api_key,
 
     return flickrobj if fn_result else None
 
+
 # -----------------------------------------------------------------------------
 # If called directly run doctests
 #

--- a/lib/FlickrApiWrapper.py
+++ b/lib/FlickrApiWrapper.py
@@ -379,7 +379,6 @@ if __name__ == "__main__":
     doctest.testmod()
 
     import os
-    import sys
 
     # Define two variables within your OS environment (api_key, secret)
     # to access flickr:

--- a/lib/FlickrApiWrapper.py
+++ b/lib/FlickrApiWrapper.py
@@ -20,6 +20,7 @@ from __future__ import division    # This way: 3 / 2 == 1.5; 3 // 2 == 1
 # -----------------------------------------------------------------------------
 # Import section
 #
+import sys
 import logging
 try:
     import httplib as httplib      # Python 2

--- a/lib/FlickrApiWrapper.py
+++ b/lib/FlickrApiWrapper.py
@@ -67,14 +67,9 @@ def isGood(res):
 
         Check res is not None and res.attrib['stat'] == "ok" for XML object
     """
-    if res is None:
-        return False
-    elif not res == "" and res.attrib['stat'] == "ok":
-        return True
-    else:
-        return False
-
-    return False if res is None else (not res == "" and res.attrib['stat'] == "ok")
+    return False\
+           if res is None\
+           else (not res == "" and res.attrib['stat'] == "ok")
 
 # -----------------------------------------------------------------------------
 def flickrapi_fn(fn_name,

--- a/lib/FlickrApiWrapper.py
+++ b/lib/FlickrApiWrapper.py
@@ -238,12 +238,14 @@ def nu_authenticate(api_key,
                   exceptsysinfo=True)
         fn_result = False
         sys.exit(4)
-    except Exception as ex:
+    except Exception as exc:
         niceerror(caught=True,
                   caughtprefix='+++Api',
                   caughtcode='003',
                   caughtmsg='Unexpected error in token_valid',
                   useniceprint=True,
+                  exceptuse=True,
+                  exceptmsg=exc,
                   exceptsysinfo=True)
         fn_result = False
         raise
@@ -263,7 +265,7 @@ def nu_authenticate(api_key,
         if sys.version_info < (3, ) \
         else input('Verifier code (NNN-NNN-NNN): ')
 
-    logging.warning('Verifier: {!s}'.format(verifier))
+    logging.warning('Verifier: %s', verifier)
 
     # Trade the request token for an access token
     try:

--- a/lib/FlickrApiWrapper.py
+++ b/lib/FlickrApiWrapper.py
@@ -186,12 +186,13 @@ def nu_authenticate(api_key,
                     secret,
                     token_cache_location):
     """ nu_authenticate
-    Authenticate user so we can upload files.
-    Assumes the cached token is not available or valid.
 
-    api_key, secret, token_cache_location, perms
-
-    Returns an instance object for the class flickrapi
+        Authenticate user so we can upload files.
+        Assumes the cached token is not available or valid.
+    
+        api_key, secret, token_cache_location, perms
+    
+        Returns an instance object for the class flickrapi
     """
 
     # Instantiate flickr for connection to flickr via flickrapi
@@ -260,7 +261,7 @@ def nu_authenticate(api_key,
         if sys.version_info < (3, ) \
         else input('Verifier code (NNN-NNN-NNN): ')
 
-    print('Verifier: {!s}'.format(verifier))
+    logging.warning('Verifier: {!s}'.format(verifier))
 
     # Trade the request token for an access token
     try:
@@ -277,7 +278,7 @@ def nu_authenticate(api_key,
                   exceptsysinfo=True)
         sys.exit(5)
 
-    NPR.niceprint('{!s} with {!s} permissions: {!s}'
+    NPR.niceprint('{!s} with [{!s}] permissions: {!s}'
                   .format('Check Authentication',
                           'delete',
                           flickrobj.token_valid(perms='delete')))
@@ -359,11 +360,6 @@ def get_cached_token(api_key,
                   exceptsysinfo=True)
         fn_result = False
         raise
-
-    # if fn_result:
-    #     return flickrobj  # flickrobj.token_cache.token
-    # else:
-    #     return None   # Error
 
     return flickrobj if fn_result else None
 

--- a/lib/FlickrApiWrapper.py
+++ b/lib/FlickrApiWrapper.py
@@ -99,6 +99,10 @@ def flickrapi_fn(fn_name,
 
     @retry(attempts=attempts, waittime=waittime, randtime=randtime)
     def retry_flickrapi_fn(kwargs):
+        """ retry_flickrapi_fn
+
+            Decorator to retry calling a function
+        """
         return fn_name(**kwargs)
 
     logging.info('fn:[%s] attempts:[%s] waittime:[%s] randtime:[%s]',
@@ -169,8 +173,8 @@ def flickrapi_fn(fn_name,
                       else isGood(fn_result))
         fn_result = None
 
-    logging.info('fn:[{!s}] success:[{!s}] result:[{!s}] errcode:[{!s}]'
-                 .format(fn_name.__name__, fn_success, fn_result, fn_errcode))
+    logging.info('fn:[%s] success:[%s] result:[%s] errcode:[%s]',
+                 fn_name.__name__, fn_success, fn_result, fn_errcode)
 
     return fn_success, fn_result, fn_errcode
 
@@ -281,7 +285,7 @@ def nu_authenticate(api_key,
                           flickrobj.token_valid(perms='delete')))
 
     # Some debug...
-    logging.info('Token Cache: [{!s}]', flickrobj.token_cache.token)
+    logging.info('Token Cache: [%s]', flickrobj.token_cache.token)
 
     return flickrobj
 
@@ -358,11 +362,12 @@ def get_cached_token(api_key,
         fn_result = False
         raise
 
-    if fn_result:
-        return flickrobj  # flickrobj.token_cache.token
-    else:
-        return None   # Error
+    # if fn_result:
+    #     return flickrobj  # flickrobj.token_cache.token
+    # else:
+    #     return None   # Error
 
+    return flickrobj if fn_result else None
 
 # -----------------------------------------------------------------------------
 # If called directly run doctests
@@ -385,28 +390,28 @@ if __name__ == "__main__":
     # export api_key=XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
     # export secret=YYYYYYYYYYYYYYYY
     #
-    flickr_config = {'api_key': os.environ['api_key'],
+    FLICKR_CONFIG = {'api_key': os.environ['api_key'],
                      'secret': os.environ['secret'],
                      'TOKEN_CACHE': os.path.join(
                          os.path.dirname(sys.argv[0]), 'token')}
 
     NPR.niceprint('-----------------------------------Connecting to Flickr...')
-    flickr = None
-    flickr = get_cached_token(
-        flickr_config['api_key'],
-        flickr_config['secret'],
-        token_cache_location=flickr_config['TOKEN_CACHE'])
+    FLICKR = None
+    FLICKR = get_cached_token(
+        FLICKR_CONFIG['api_key'],
+        FLICKR_CONFIG['secret'],
+        token_cache_location=FLICKR_CONFIG['TOKEN_CACHE'])
 
-    if flickr is None:
-        flickr = nu_authenticate(
-            flickr_config['api_key'],
-            flickr_config['secret'],
-            token_cache_location=flickr_config['TOKEN_CACHE'])
+    if FLICKR is None:
+        FLICKR = nu_authenticate(
+            FLICKR_CONFIG['api_key'],
+            FLICKR_CONFIG['secret'],
+            token_cache_location=FLICKR_CONFIG['TOKEN_CACHE'])
 
-    if flickr is not None:
+    if FLICKR is not None:
         NPR.niceprint('-----------------------------------Number of Photos...')
         get_success, get_result, get_errcode = flickrapi_fn(
-            flickr.people.getPhotos,
+            FLICKR.people.getPhotos,
             (),
             dict(user_id="me", per_page=1),
             2, 10, True)

--- a/lib/FlickrApiWrapper.py
+++ b/lib/FlickrApiWrapper.py
@@ -76,14 +76,14 @@ def isGood(res):
 
 
 # -----------------------------------------------------------------------------
-def nu_flickrapi_fn(fn_name,
-                    fn_args,  # format: ()
-                    fn_kwargs,  # format: dict()
-                    attempts=3,
-                    waittime=5,
-                    randtime=False,
-                    caughtcode='000'):
-    """ nu_flickrapi_fn
+def flickrapi_fn(fn_name,
+                 fn_args,  # format: ()
+                 fn_kwargs,  # format: dict()
+                 attempts=3,
+                 waittime=5,
+                 randtime=False,
+                 caughtcode='000'):
+    """ flickrapi_fn
 
         Runs flickrapi fn_name function handing over **fn_kwargs.
         It retries attempts, waittime, randtime with @retry
@@ -287,11 +287,11 @@ def nu_authenticate(api_key,
 
 
 # -----------------------------------------------------------------------------
-def nu_get_cached_token(api_key,
-                        secret,
-                        token_cache_location='token',
-                        perms='delete'):
-    """ nu_get_cached_token
+def get_cached_token(api_key,
+                     secret,
+                     token_cache_location='token',
+                     perms='delete'):
+    """ get_cached_token
 
         Attempts to get the flickr token from disk.
 
@@ -392,7 +392,7 @@ if __name__ == "__main__":
 
     NPR.niceprint('-----------------------------------Connecting to Flickr...')
     flickr = None
-    flickr = nu_get_cached_token(
+    flickr = get_cached_token(
         flickr_config['api_key'],
         flickr_config['secret'],
         token_cache_location=flickr_config['TOKEN_CACHE'])
@@ -405,7 +405,7 @@ if __name__ == "__main__":
 
     if flickr is not None:
         NPR.niceprint('-----------------------------------Number of Photos...')
-        get_success, get_result, get_errcode = nu_flickrapi_fn(
+        get_success, get_result, get_errcode = flickrapi_fn(
             flickr.people.getPhotos,
             (),
             dict(user_id="me", per_page=1),

--- a/lib/FlickrApiWrapper.py
+++ b/lib/FlickrApiWrapper.py
@@ -79,8 +79,8 @@ def isGood(res):
 
 # -----------------------------------------------------------------------------
 def nu_flickrapi_fn(fn_name,
-                    fn_args=(),
-                    fn_kwargs=dict(),
+                    fn_args,  # format: ()
+                    fn_kwargs,  # format: dict()
                     attempts=3,
                     waittime=5,
                     randtime=False,

--- a/lib/FlickrApiWrapper.py
+++ b/lib/FlickrApiWrapper.py
@@ -415,4 +415,4 @@ if __name__ == "__main__":
 
         if GET_SUCCESS and GET_ERRCODE == 0:
             NPR.niceprint('Number of Photos=[{!s}]'
-                          .format(get_result.find('photos').attrib['total']))
+                          .format(GET_RESULT.find('photos').attrib['total']))

--- a/lib/FlickrUploadr.py
+++ b/lib/FlickrUploadr.py
@@ -149,11 +149,12 @@ def chunk(itlist, size):
 
         Divides an iterable in slices/chunks of size size
 
-        >>> for a in chunk([ 1, 2, 3, 4, 5, 6], 2):
+        >>> for a in chunk([ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 3):
         ...     len(a)
-        2
-        2
-        2
+        3
+        3
+        3
+        1
     """
     itlist = iter(itlist)
     # lambda: creates a returning expression function
@@ -194,6 +195,13 @@ def set_name_from_file(afile, afiles_dir, afull_set_name):
         FULL_SET_NAME:
                False=> 05
                 True=> 2014/05/05
+
+        >>> set_name_from_file('/some/photos/Parent/Album/unique file.jpg',\
+        '/some/photos', False)
+        'Album'
+        >>> set_name_from_file('/some/photos/Parent/Album/unique file.jpg',\
+        '/some/photos', True)
+        'Parent/Album'
     """
 
     assert len(afile) > 0, NP.niceassert('len({!s}) is not > 0:'

--- a/lib/FlickrUploadr.py
+++ b/lib/FlickrUploadr.py
@@ -906,7 +906,8 @@ class Uploadr(object):
         # Update Date/Time on Flickr for Video files
         # Flickr doesn't read it from the video file itself.
         filetype = mimetypes.guess_type(xfile)
-        logging.info('filetype is:[%s]', 'None'
+        logging.info('filetype is:[%s]',
+                     'None'
                      if filetype is None
                      else filetype[0])
 
@@ -3224,7 +3225,7 @@ class Uploadr(object):
                              .format(tfind, tid))
 
             if not tfind:
-                get_success, res_add_tag, get_errcode = faw.flickrapi_fn(
+                get_success, _, get_errcode = faw.flickrapi_fn(
                     self.nuflickr.photos.addTags, (),
                     dict(photo_id=f[0],
                          tags='album:"{}"'.format(f[2]
@@ -3367,7 +3368,7 @@ class Uploadr(object):
                                      .format(tfind, tid))
 
                     if not tfind:
-                        get_success, res_add_tag, get_errcode = \
+                        get_success, _, get_errcode = \
                             faw.flickrapi_fn(
                                 self.nuflickr.photos.addTags, (),
                                 dict(photo_id=row[0],

--- a/lib/FlickrUploadr.py
+++ b/lib/FlickrUploadr.py
@@ -67,14 +67,14 @@ import lib.FlickrApiWrapper as faw
 #   strunicodeout       = from NicePrint module
 #   niceerror           = from NicePrint module
 #   retry               = from rate_limited
-#   isGood              = from FlickrApiWrapper
+#   is_good             = from FlickrApiWrapper
 # -----------------------------------------------------------------------------
 UPLDRConstants = UPLDRConstantsClass.UPLDRConstants()
 NP = NicePrint.NicePrint()
 strunicodeout = NP.strunicodeout
 niceerror = NP.niceerror
 retry = rate_limited.retry
-isGood = faw.isGood
+is_good = faw.is_good
 
 NUTIME = time
 # -----------------------------------------------------------------------------
@@ -1013,7 +1013,7 @@ class Uploadr(object):
             res_set_date = self.photos_set_dates(xfile_id,
                                                  str(video_date))
 
-            if isGood(res_set_date):
+            if is_good(res_set_date):
                 NP.niceprint('Successful date:[{!s}] '
                              'for file:[{!s}]'
                              .format(strunicodeout(video_date),
@@ -1350,13 +1350,13 @@ class Uploadr(object):
                         )
 
                         logging.info('Output for uploadResp:[%s]',
-                                     isGood(uploadResp))
+                                     is_good(uploadResp))
                         logging.debug(xml.etree.ElementTree.tostring(
                             uploadResp,
                             encoding='utf-8',
                             method='xml'))
 
-                        if isGood(uploadResp):
+                        if is_good(uploadResp):
                             ZuploadOK = True
                             # Save photo_id returned from Flickr upload
                             photo_id = uploadResp.findall('photoid')[0].text
@@ -1756,9 +1756,9 @@ class Uploadr(object):
                         replaceResp,
                         encoding='utf-8',
                         method='xml'))
-                    logging.info('replaceResp:[%s]', isGood(replaceResp))
+                    logging.info('replaceResp:[%s]', is_good(replaceResp))
 
-                    if isGood(replaceResp):
+                    if is_good(replaceResp):
                         # Update checksum tag at this time.
 
                         get_success, res_add_tag, get_errcode = \
@@ -1802,7 +1802,7 @@ class Uploadr(object):
                                     logging.info('Removing tag_id:[%s]',
                                                  tag_id)
                                     remtagResp = self.photos_remove_tag(tag_id)
-                                    if isGood(remtagResp):
+                                    if is_good(remtagResp):
                                         NP.niceprint('    Tag removed:[{!s}]'
                                                      .format(
                                                          strunicodeout(file)))
@@ -1831,19 +1831,19 @@ class Uploadr(object):
                                          'to replace, skipping')
                     continue
 
-            if (not isGood(replaceResp)) or \
-                (not isGood(res_add_tag)) or \
-                    (not isGood(res_get_info)):
+            if (not is_good(replaceResp)) or \
+                (not is_good(res_add_tag)) or \
+                    (not is_good(res_get_info)):
                 NP.niceprint('Issue replacing:[{!s}]'
                              .format(strunicodeout(file)))
 
-            if not isGood(replaceResp):
+            if not is_good(replaceResp):
                 raise IOError(replaceResp)
 
-            if not isGood(res_add_tag):
+            if not is_good(res_add_tag):
                 raise IOError(res_add_tag)
 
-            if not isGood(res_get_info):
+            if not is_good(res_get_info):
                 raise IOError(res_get_info)
 
             NP.niceprint('  Replaced file:[{!s}].'

--- a/lib/FlickrUploadr.py
+++ b/lib/FlickrUploadr.py
@@ -1006,7 +1006,9 @@ class Uploadr(object):
 
             if self.args.verbose:
                 NP.niceprint('   Setting Date:[{!s}] for file:[{!s}] Id=[{!s}]'
-                             .format(datetxt, strunicodeout(xfile), photo_id))
+                             .format(video_date,
+                                     strunicodeout(xfile),
+                                     xfile_id))
 
             res_set_date = self.photos_set_dates(xfile_id,
                                                  str(video_date))

--- a/lib/FlickrUploadr.py
+++ b/lib/FlickrUploadr.py
@@ -204,8 +204,8 @@ def set_name_from_file(afile, afiles_dir, afull_set_name):
         'Parent/Album'
     """
 
-    assert len(afile) > 0, NP.niceassert('len({!s}) is not > 0:'
-                                         .format(strunicodeout(afile)))
+    assert afile, NP.niceassert('[{!s}] is empty!'
+                                .format(strunicodeout(afile)))
 
     logging.debug('set_name_from_file in: '
                   'afile:[%s] afiles_dir=[%s] afull_set_name:[%s]',
@@ -3022,7 +3022,7 @@ class Uploadr(object):
         # Number of pics with specified checksum
         # CODING: Protect issue #66. Flickr returns attrib == '' instead of 0
         # Set 'Number of pics with specified checksum' to 0 and return.
-        if len(searchIsUploaded.find('photos').attrib['total']) == 0:
+        if not searchIsUploaded.find('photos').attrib['total']:
             returnPhotoUploaded = 0
             logging.error(' IS_UPLOADED:[ERROR#3]: Invalid return. Confinuing')
             NP.niceprint(' IS_UPLOADED:[ERROR#3]: Invalid return. Confinuing',
@@ -3099,7 +3099,7 @@ class Uploadr(object):
 
                 # B) checksum, title, empty setName,       Count=1
                 #                 THEN EXISTS, ASSIGN SET IF tag album IS FOUND
-                if len(resp.findall('set')) == 0:
+                if not resp.findall('set'):
                     # CODING: Consider one additional result for PHOTO UPLOADED
                     # WITHOUT SET WITH ALBUM TAG when row exists on DB. Mark
                     # such row on the database files.set_id to null

--- a/lib/FlickrUploadr.py
+++ b/lib/FlickrUploadr.py
@@ -3913,7 +3913,7 @@ class Uploadr(object):
                         strunicodeout(row.attrib['title']))
 
                     tags_success, tags_result, tags_errcode = faw.flickrapi_fn(
-                        nuflickr.tags.getListPhoto,
+                        self.nuflickr.tags.getListPhoto,
                         (),
                         dict(photo_id=row.attrib['id']),
                         2, 2, False)

--- a/lib/FlickrUploadr.py
+++ b/lib/FlickrUploadr.py
@@ -3024,8 +3024,8 @@ class Uploadr(object):
         # Set 'Number of pics with specified checksum' to 0 and return.
         if len(searchIsUploaded.find('photos').attrib['total']) == 0:
             returnPhotoUploaded = 0
-            logging.error(' IS_UPLOADED:[ERROR#3]: len.photos.total == 0')
-            NP.niceprint(' IS_UPLOADED:[ERROR#3]: len.photos.total == 0',
+            logging.error(' IS_UPLOADED:[ERROR#3]: Invalid return. Confinuing')
+            NP.niceprint(' IS_UPLOADED:[ERROR#3]: Invalid return. Confinuing',
                          fname='isuploaded')
         else:
             returnPhotoUploaded = int(searchIsUploaded

--- a/lib/FlickrUploadr.py
+++ b/lib/FlickrUploadr.py
@@ -3303,7 +3303,7 @@ class Uploadr(object):
             logging.warning('       Find Tag:[%s] TagId:[%s]',
                             tfind, tid)
             if self.args.verbose:
-                NP.niceprint('       Find Tag::[{!s}] TagId:[{!s}]'
+                NP.niceprint('       Find Tag:[{!s}] TagId:[{!s}]'
                              .format(tfind, tid))
 
             if not tfind:
@@ -3333,7 +3333,7 @@ class Uploadr(object):
                 logging.warning('      Found Tag:[%s] TagId:[{%s]',
                                 tfind, tid)
                 if self.args.verbose:
-                    NP.niceprint('      Found Tag::[{!s}] TagId:[{!s}]'
+                    NP.niceprint('      Found Tag:[{!s}] TagId:[{!s}]'
                                  .format(tfind, tid))
 
             logging.debug('===Multiprocessing=== in.mutex.acquire(w)')
@@ -3446,7 +3446,7 @@ class Uploadr(object):
                     logging.warning('       Find Tag:[%s] TagId:[%s]',
                                     tfind, tid)
                     if self.args.verbose:
-                        NP.niceprint('       Find Tag::[{!s}] TagId:[{!s}]'
+                        NP.niceprint('       Find Tag:[{!s}] TagId:[{!s}]'
                                      .format(tfind, tid))
 
                     if not tfind:
@@ -3478,7 +3478,7 @@ class Uploadr(object):
                         logging.warning('      Found Tag:[%s] TagId:[{%s]',
                                         tfind, tid)
                         if self.args.verbose:
-                            NP.niceprint('      Found Tag::[{!s}] TagId:[{!s}]'
+                            NP.niceprint('      Found Tag:[{!s}] TagId:[{!s}]'
                                          .format(tfind, tid))
 
                     NP.niceprocessedfiles(count, countTotal, False)

--- a/lib/FlickrUploadr.py
+++ b/lib/FlickrUploadr.py
@@ -29,9 +29,7 @@ import sqlite3 as lite
 import hashlib
 import subprocess
 import xml
-# Avoids error on some systems:
-#    AttributeError: 'module' object has no attribute 'etree'
-#    on logging.info(xml.etree.ElementTree.tostring(...
+# Prevents error "AttributeError: 'module' object has no attribute 'etree'"
 try:
     DUMMYXML = xml.etree.ElementTree.tostring(
         xml.etree.ElementTree.Element('xml.etree'),
@@ -3898,7 +3896,6 @@ class Uploadr(object):
             # List pics not in sets (if within a parameter, default 10)
             # (per_page=min(self.args.list_photos_not_in_set, 500):
             #       find('photos').attrib['total']
-
             get_success, get_result, get_errcode = faw.nu_flickrapi_fn(
                 self.nuflickr.photos.getNotInSet,
                 (),
@@ -3911,9 +3908,25 @@ class Uploadr(object):
                     logging.info('Photo Not in Set: id:[%s] title:[%s]',
                                  row.attrib['id'],
                                  strunicodeout(row.attrib['title']))
-                    NP.niceprint('Photo Not in Set: id:[{!s}] title:[{!s}]'
-                                 .format(row.attrib['id'],
-                                         strunicodeout(row.attrib['title'])))
+                    output_str = 'id:{!s}|title:{!s}|'.format(
+                        row.attrib['id'],
+                        strunicodeout(row.attrib['title']))
+
+                    tags_success, tags_result, tags_errcode = nu_flickrapi_fn(
+                        flickr.tags.getListPhoto,
+                        (),
+                        dict(photo_id=row.attrib['id']),
+                        2, 2, False)
+                    
+                    if get_success and get_errcode == 0:
+                        for tag in get_result.find('photo')\
+                                .find('tags').findall('tag'):
+                            output_str += 'tag_attrib:{!s}|'\
+                                          .format(
+                                NP.strunicodeout(
+                                tag.attrib['raw']))
+
+                    NP.niceprint(output_str)
 
                     logging.info('count=[%s]', count)
                     if ((count == 500) or

--- a/lib/FlickrUploadr.py
+++ b/lib/FlickrUploadr.py
@@ -2473,7 +2473,7 @@ class Uploadr(object):
         """
 
         logging.info('   Creating set:[%s]', strunicodeout(setName))
-        NP.niceprint('   Creating set:[%s]'.format(strunicodeout(setName)))
+        NP.niceprint('   Creating set:[{!s}]'.format(strunicodeout(setName)))
 
         if self.args.dry_run:
             return True

--- a/lib/FlickrUploadr.py
+++ b/lib/FlickrUploadr.py
@@ -230,8 +230,8 @@ def rate_5_callspersecond():
 
         Pace the calls rate within a specific function
 
-          n   = for n calls per second  (ex. 3 means 3 calls per second)
-          1/n = for n seconds per call (ex. 0.5 means 4 seconds in between calls)
+          n   = n calls per second  (ex. 3 means 3 calls per second)
+          1/n = n seconds per call (ex. 0.5 means 4 seconds in between calls)
     """
     logging.debug('rate_limit timestamp:[%s]', time.strftime('%T'))
 

--- a/lib/FlickrUploadr.py
+++ b/lib/FlickrUploadr.py
@@ -1684,25 +1684,25 @@ class Uploadr(object):
     #                     as it is not used)
     #   file            = file to be uploaded to replace existing file
     #   file_id         = ID of the photo being replaced
-    #   oldfileMd5      = Old file MD5 (required to update checksum tag
+    #   oldfile_md5     = Old file MD5 (required to update checksum tag
     #                     on Flikr)
-    #   fileMd5         = New file MD5
+    #   file_md5        = New file MD5
     #   last_modified   = date/time last modification of the file to update
     #                     database
     #   cur             = current cursor for updating Database
     #   con             = current DB connection
     #
     def replacePhoto(self, lock, file, file_id,
-                     oldFileMd5, fileMd5, last_modified, cur, con):
+                     oldfile_md5, file_md5, last_modified, cur, con):
         """ replacePhoto
         lock            = parameter for multiprocessing control of access to DB
                           (if self.args.processes = 0 then lock can be None
                           as it is not used)
         file            = file to be uploaded to replace existing file
         file_id         = ID of the photo being replaced
-        oldfileMd5      = Old file MD5 (required to update checksum tag
+        oldfile_md5     = Old file MD5 (required to update checksum tag
                           on Flikr)
-        fileMd5         = New file MD5
+        file_md5        = New file MD5
         last_modified   = date/time last modification of the file to update
                           database
         cur             = current cursor for updating Database
@@ -1765,7 +1765,7 @@ class Uploadr(object):
                             faw.flickrapi_fn(
                                 self.nuflickr.photos.addTags, (),
                                 dict(photo_id=file_id,
-                                     tags='checksum:{}'.format(fileMd5)),
+                                     tags='checksum:{}'.format(file_md5)),
                                 2, 2, False, caughtcode='055')
 
                         if get_success and get_errcode == 0:
@@ -1778,7 +1778,7 @@ class Uploadr(object):
                                     2, 2, False, caughtcode='056')
 
                             if gi_success and gi_errcode == 0:
-                                # find tag checksum with oldFileMd5
+                                # find tag checksum with oldfile_md5
                                 # later use such tag_id to delete it
                                 tag_id = None
                                 for tag in res_get_info\
@@ -1786,7 +1786,7 @@ class Uploadr(object):
                                     .find('tags')\
                                         .findall('tag'):
                                     if (tag.attrib['raw'] ==
-                                            'checksum:{}'.format(oldFileMd5)):
+                                            'checksum:{}'.format(oldfile_md5)):
                                         tag_id = tag.attrib['id']
                                         logging.info('   Found tag_id:[%s]',
                                                      tag_id)
@@ -1855,7 +1855,7 @@ class Uploadr(object):
             try:
                 cur.execute('UPDATE files SET md5 = ?,last_modified = ? '
                             'WHERE files_id = ?',
-                            (fileMd5, last_modified, file_id))
+                            (file_md5, last_modified, file_id))
                 con.commit()
             except lite.Error as err:
                 niceerror(caught=True,

--- a/lib/FlickrUploadr.py
+++ b/lib/FlickrUploadr.py
@@ -66,15 +66,11 @@ import lib.FlickrApiWrapper as faw
 #
 #   strunicodeout       = from NicePrint module
 #   niceerror           = from NicePrint module
-#   retry               = from rate_limited
-#   is_good             = from FlickrApiWrapper
 # -----------------------------------------------------------------------------
-UPLDRConstants = UPLDRConstantsClass.UPLDRConstants()
+UPLDR_K = UPLDRConstantsClass.UPLDRConstants()
 NP = NicePrint.NicePrint()
 strunicodeout = NP.strunicodeout
 niceerror = NP.niceerror
-retry = rate_limited.retry
-is_good = faw.is_good
 
 NUTIME = time
 # -----------------------------------------------------------------------------
@@ -1013,7 +1009,7 @@ class Uploadr(object):
             res_set_date = self.photos_set_dates(xfile_id,
                                                  str(video_date))
 
-            if is_good(res_set_date):
+            if faw.is_good(res_set_date):
                 NP.niceprint('Successful date:[{!s}] '
                              'for file:[{!s}]'
                              .format(strunicodeout(video_date),
@@ -1350,13 +1346,13 @@ class Uploadr(object):
                         )
 
                         logging.info('Output for uploadResp:[%s]',
-                                     is_good(uploadResp))
+                                     faw.is_good(uploadResp))
                         logging.debug(xml.etree.ElementTree.tostring(
                             uploadResp,
                             encoding='utf-8',
                             method='xml'))
 
-                        if is_good(uploadResp):
+                        if faw.is_good(uploadResp):
                             ZuploadOK = True
                             # Save photo_id returned from Flickr upload
                             photo_id = uploadResp.findall('photoid')[0].text
@@ -1627,7 +1623,7 @@ class Uploadr(object):
                 try:
                     logging.warning('CHANGES row[6]=[%s-(%s)]',
                                     NUTIME.strftime(
-                                        UPLDRConstants.TimeFormat,
+                                        UPLDR_K.TimeFormat,
                                         NUTIME.localtime(row[6])),
                                     row[6])
                     if row[6] is None:
@@ -1756,9 +1752,9 @@ class Uploadr(object):
                         replaceResp,
                         encoding='utf-8',
                         method='xml'))
-                    logging.info('replaceResp:[%s]', is_good(replaceResp))
+                    logging.info('replaceResp:[%s]', faw.is_good(replaceResp))
 
-                    if is_good(replaceResp):
+                    if faw.is_good(replaceResp):
                         # Update checksum tag at this time.
 
                         get_success, res_add_tag, get_errcode = \
@@ -1802,7 +1798,7 @@ class Uploadr(object):
                                     logging.info('Removing tag_id:[%s]',
                                                  tag_id)
                                     remtagResp = self.photos_remove_tag(tag_id)
-                                    if is_good(remtagResp):
+                                    if faw.is_good(remtagResp):
                                         NP.niceprint('    Tag removed:[{!s}]'
                                                      .format(
                                                          strunicodeout(file)))
@@ -1831,19 +1827,19 @@ class Uploadr(object):
                                          'to replace, skipping')
                     continue
 
-            if (not is_good(replaceResp)) or \
-                (not is_good(res_add_tag)) or \
-                    (not is_good(res_get_info)):
+            if (not faw.is_good(replaceResp)) or \
+                (not faw.is_good(res_add_tag)) or \
+                    (not faw.is_good(res_get_info)):
                 NP.niceprint('Issue replacing:[{!s}]'
                              .format(strunicodeout(file)))
 
-            if not is_good(replaceResp):
+            if not faw.is_good(replaceResp):
                 raise IOError(replaceResp)
 
-            if not is_good(res_add_tag):
+            if not faw.is_good(res_add_tag):
                 raise IOError(res_add_tag)
 
-            if not is_good(res_get_info):
+            if not faw.is_good(res_get_info):
                 raise IOError(res_get_info)
 
             NP.niceprint('  Replaced file:[{!s}].'
@@ -2128,7 +2124,7 @@ class Uploadr(object):
         while True:
             NP.niceprint(' Daemon mode go:[{!s}]'
                          .format(NUTIME.strftime(
-                             UPLDRConstants.TimeFormat)))
+                             UPLDR_K.TimeFormat)))
             # run upload
             self.upload()
             NP.niceprint('Daemon mode out:[{!s}]'
@@ -3534,7 +3530,7 @@ class Uploadr(object):
                               strunicodeout(str(row[2])),
                               strunicodeout(str(row[3])),
                               strunicodeout(str(row[4])),
-                              NUTIME.strftime(UPLDRConstants.TimeFormat,
+                              NUTIME.strftime(UPLDR_K.TimeFormat,
                                               NUTIME.localtime(row[5]))))
                 sys.stdout.flush()
 
@@ -3659,7 +3655,7 @@ class Uploadr(object):
                         dict(photo_id=row.attrib['id']),
                         2, 2, False, caughtcode='411')
 
-                    if get_success and get_errcode == 0:
+                    if tags_success and tags_errcode == 0:
                         for tag in tags_result.find('photo')\
                                 .find('tags').findall('tag'):
                             output_str += 'tag_attrib={!s}|'\
@@ -3695,20 +3691,20 @@ class Uploadr(object):
                            = False => Release
         """
 
-        useDBLockReturn = False
+        use_dblock_return = False
 
         logging.debug('Entering useDBLock with useDBoperation:[%s].',
                       useDBoperation)
 
         if useDBthisLock is None:
             logging.debug('useDBLock: useDBthisLock is [None].')
-            return useDBLockReturn
+            return use_dblock_return
 
         logging.debug('useDBLock: useDBthisLock.semlock:[%s].',
                       useDBthisLock._semlock)
 
         if useDBoperation is None:
-            return useDBLockReturn
+            return use_dblock_return
 
         if (self.args.processes is not None) and\
            (self.args.processes) and \
@@ -3718,7 +3714,7 @@ class Uploadr(object):
                 logging.debug('===Multiprocessing=== -->[ ].lock.acquire')
                 try:
                     if useDBthisLock.acquire():
-                        useDBLockReturn = True
+                        use_dblock_return = True
                 except BaseException:
                     niceerror(caught=True,
                               caughtprefix='+++ ',
@@ -3733,7 +3729,7 @@ class Uploadr(object):
                 logging.debug('===Multiprocessing=== <--[ ].lock.release')
                 try:
                     useDBthisLock.release()
-                    useDBLockReturn = True
+                    use_dblock_return = True
                 except BaseException:
                     niceerror(caught=True,
                               caughtprefix='+++ ',
@@ -3747,15 +3743,15 @@ class Uploadr(object):
 
             logging.info('Exiting useDBLock with useDBoperation:[%s]. '
                          'Result:[%s]',
-                         useDBoperation, useDBLockReturn)
+                         useDBoperation, use_dblock_return)
         else:
-            useDBLockReturn = True
+            use_dblock_return = True
             logging.warning('(No multiprocessing. Nothing to do) '
                             'Exiting useDBLock with useDBoperation:[%s]. '
                             'Result:[%s]',
-                            useDBoperation, useDBLockReturn)
+                            useDBoperation, use_dblock_return)
 
-        return useDBLockReturn
+        return use_dblock_return
 
 
 # -----------------------------------------------------------------------------

--- a/lib/FlickrUploadr.py
+++ b/lib/FlickrUploadr.py
@@ -2901,7 +2901,8 @@ class Uploadr(object):
                               useniceprint=True)
 
                 if foundSets is None:
-                    logging.info('Adding set [%s] (%s) with primary photo [%s].',
+                    logging.info('Adding set [%s] (%s) '
+                                 'with primary photo [%s].',
                                  setId,
                                  'None'
                                  if setName is None
@@ -2919,13 +2920,13 @@ class Uploadr(object):
                         con.commit()
 
                     except lite.Error as err:
-                         niceerror(caught=True,
-                                   caughtprefix='+++ DB',
-                                   caughtcode='165',
-                                   caughtmsg='DB error on INSERT INTO '
-                                   'sets: [{!s}]'
-                                   .format(err.args[0]),
-                                   useniceprint=True)
+                        niceerror(caught=True,
+                                  caughtprefix='+++ DB',
+                                  caughtcode='165',
+                                  caughtmsg='DB error on INSERT INTO '
+                                  'sets: [{!s}]'
+                                  .format(err.args[0]),
+                                  useniceprint=True)
                 else:
                     logging.info('Set found on DB:[%s]',
                                  strunicodeout(setName))

--- a/lib/FlickrUploadr.py
+++ b/lib/FlickrUploadr.py
@@ -339,7 +339,6 @@ class Uploadr(object):
 
             Returns the credentials attached to an authentication token.
         """
-        result = False
         logging.warning(
             'check_token:(self.token is None):[%s]'
             'check_token:(nuflickr is None):[%s]'
@@ -350,10 +349,9 @@ class Uploadr(object):
             if self.nuflickr is not None
             else 'Not valid as nuflickr is None')
 
-        if self.nuflickr is not None:
-            result = self.nuflickr.token_cache.token is not None
-
-        return result
+        return self.nuflickr.token_cache.token is not None\
+            if self.nuflickr is not None\
+            else False
 
     # -------------------------------------------------------------------------
     # authenticate
@@ -1829,8 +1827,7 @@ class Uploadr(object):
                     (not faw.is_good(res_get_info)):
                 NP.niceprint('Issue replacing:[{!s}]'
                              .format(strunicodeout(file)))
-                logging.error('Issue replacing:[{!s}]'
-                              .format(strunicodeout(file)))
+                logging.error('Issue replacing:[%s]', strunicodeout(file))
 
             if not faw.is_good(replaceResp):
                 raise IOError(replaceResp)
@@ -1841,10 +1838,10 @@ class Uploadr(object):
             if not faw.is_good(res_get_info):
                 raise IOError(res_get_info)
 
-            NP.niceprint('  Replaced file:[{!s}].'
+            NP.niceprint('  Replaced file:[{!s}]'
                          .format(strunicodeout(file)))
-            logging.warning('  Replaced file:[{!s}].'
-                            .format(strunicodeout(file)))
+            logging.warning('  Replaced file:[%s]',
+                            strunicodeout(file))
 
             # Update the db the file uploaded
             # Control for when running multiprocessing set locking

--- a/lib/FlickrUploadr.py
+++ b/lib/FlickrUploadr.py
@@ -3917,21 +3917,21 @@ class Uploadr(object):
                         (),
                         dict(photo_id=row.attrib['id']),
                         2, 2, False)
-                    
+
                     if get_success and get_errcode == 0:
                         for tag in get_result.find('photo')\
                                 .find('tags').findall('tag'):
                             output_str += 'tag_attrib:{!s}|'\
                                           .format(
-                                NP.strunicodeout(
-                                tag.attrib['raw']))
+                                              NP.strunicodeout(
+                                                  tag.attrib['raw']))
 
                     NP.niceprint(output_str)
 
                     logging.info('count=[%s]', count)
-                    if ((count == 500) or
-                            (count >= (self.args.list_photos_not_in_set - 1))
-                            or (count >= (countnotinsets - 1))):
+                    if (count == 500 or
+                            count >= (self.args.list_photos_not_in_set - 1) or
+                            count >= (countnotinsets - 1)):
                         logging.info('Stopped at photo [%s] listing '
                                      'photos not in a set', count)
                         break

--- a/lib/FlickrUploadr.py
+++ b/lib/FlickrUploadr.py
@@ -2460,7 +2460,6 @@ class Uploadr(object):
                       useniceprint=True)
             con.close()
 
-
     # -------------------------------------------------------------------------
     # createSet
     #

--- a/lib/FlickrUploadr.py
+++ b/lib/FlickrUploadr.py
@@ -3316,16 +3316,18 @@ class Uploadr(object):
                     2, 2, False, caughtcode='214')
 
                 a_result = get_success and get_errcode == 0
-                logging.warning('%s: Photo_id:[%s]. ',
+                logging.warning('%s: Photo_id:[%s] [%s] ',
                                 'Added album tag'
                                 if a_result
-                                else 'Failed tagging',
-                                str(row[0]))
-                NP.niceprint('{!s}: Photo_id:[{!s}]. '
-                             .format(' Failed tagging'
+                                else ' Failed tagging',
+                                str(f[0]),
+                                strunicodeout(f[1]))
+                NP.niceprint('{!s}: Photo_id:[{!s}] [{!s}]'
+                             .format('Added album tag'
                                      if a_result
-                                     else 'Failed tagging',
-                                     str(row[0])),
+                                     else ' Failed tagging',
+                                     str(f[0]),
+                                     strunicodeout(f[1])),
                              fname='addAlbumMigrate')
             else:
                 logging.warning('      Found Tag:[%s] TagId:[{%s]',
@@ -3459,16 +3461,18 @@ class Uploadr(object):
                                 2, 2, False, caughtcode='218')
 
                         a_result = get_success and get_errcode == 0
-                        logging.warning('%s: Photo_id:[%s]. ',
+                        logging.warning('%s: Photo_id:[%s] [%s]',
                                         'Added album tag'
                                         if a_result
-                                        else 'Failed tagging',
-                                        str(row[0]))
-                        NP.niceprint('{!s}: Photo_id:[{!s}]. '
-                                     .format(' Failed tagging'
+                                        else ' Failed tagging',
+                                        str(row[0]),
+                                        strunicodeout(row[1]))
+                        NP.niceprint('{!s}: Photo_id:[{!s}] [{!s}]'
+                                     .format('Added album tag'
                                              if a_result
-                                             else 'Failed tagging',
-                                             str(row[0])),
+                                             else ' Failed tagging',
+                                             str(row[0]),
+                                             strunicodeout(row[1])),
                                      fname='addAlbumMigrate')
                     else:
                         logging.warning('      Found Tag:[%s] TagId:[{%s]',

--- a/lib/FlickrUploadr.py
+++ b/lib/FlickrUploadr.py
@@ -2043,7 +2043,7 @@ class Uploadr(object):
 
         NP.niceprint('  Deleting file:[{!s}]'.format(strunicodeout(file[1])))
 
-        get_success, get_result, get_errcode = faw.nu_flickrapi_fn(
+        get_success, get_result, get_errcode = faw.flickrapi_fn(
             self.nuflickr.photos.delete,
             (),
             dict(photo_id=str(file[0])),
@@ -2383,7 +2383,7 @@ class Uploadr(object):
         con.text_factory = str
         bcur = con.cursor()
 
-        get_success, get_result, get_errcode = faw.nu_flickrapi_fn(
+        get_success, get_result, get_errcode = faw.flickrapi_fn(
             self.nuflickr.photosets.addPhoto,
             (),
             dict(photoset_id=str(setId),
@@ -2478,7 +2478,7 @@ class Uploadr(object):
         if self.args.dry_run:
             return True
 
-        get_success, get_result, get_errcode = faw.nu_flickrapi_fn(
+        get_success, get_result, get_errcode = faw.flickrapi_fn(
             self.nuflickr.photosets.create,
             (),
             dict(title=setName,
@@ -2823,7 +2823,7 @@ class Uploadr(object):
         con.text_factory = str
         cur = con.cursor()
 
-        get_success, get_result, get_errcode = faw.nu_flickrapi_fn(
+        get_success, get_result, get_errcode = faw.flickrapi_fn(
             self.nuflickr.photosets.getList,
             (),
             dict(),
@@ -3844,7 +3844,7 @@ class Uploadr(object):
                           useniceprint=True)
 
         # Total FLickr photos count: find('photos').attrib['total'] -----------
-        get_success, get_result, get_errcode = faw.nu_flickrapi_fn(
+        get_success, get_result, get_errcode = faw.flickrapi_fn(
             self.nuflickr.people.getPhotos,
             (),
             dict(user_id="me", per_page=1),
@@ -3857,7 +3857,7 @@ class Uploadr(object):
             countflickr = -1
 
         # Total FLickr photos not in set: find('photos').attrib['total'] ------
-        get_success, get_result, get_errcode = faw.nu_flickrapi_fn(
+        get_success, get_result, get_errcode = faw.flickrapi_fn(
             self.nuflickr.photos.getNotInSet,
             (),
             dict(per_page=1),
@@ -3896,7 +3896,7 @@ class Uploadr(object):
             # List pics not in sets (if within a parameter, default 10)
             # (per_page=min(self.args.list_photos_not_in_set, 500):
             #       find('photos').attrib['total']
-            get_success, get_result, get_errcode = faw.nu_flickrapi_fn(
+            get_success, get_result, get_errcode = faw.flickrapi_fn(
                 self.nuflickr.photos.getNotInSet,
                 (),
                 dict(per_page=min(self.args.list_photos_not_in_set, 500)),
@@ -3912,8 +3912,8 @@ class Uploadr(object):
                         row.attrib['id'],
                         strunicodeout(row.attrib['title']))
 
-                    tags_success, tags_result, tags_errcode = nu_flickrapi_fn(
-                        flickr.tags.getListPhoto,
+                    tags_success, tags_result, tags_errcode = faw.flickrapi_fn(
+                        nuflickr.tags.getListPhoto,
                         (),
                         dict(photo_id=row.attrib['id']),
                         2, 2, False)

--- a/lib/FlickrUploadr.py
+++ b/lib/FlickrUploadr.py
@@ -3184,9 +3184,9 @@ class Uploadr(object):
         """ photos_find_tag
 
             Determines if intag is assigned to a pic.
-
-            found_tag = False or True
-            tag_id = tag_id if found
+            Returns:
+                found_tag = False/True
+                tag_id    = tag_id if found
         """
 
         logging.info('find_tag: photo:[%s] intag:[%s]', photo_id, intag)
@@ -3294,35 +3294,19 @@ class Uploadr(object):
             setName = set_name_from_file(f[1],
                                          self.xcfg.FILES_DIR,
                                          self.xcfg.FULL_SET_NAME)
-            try:
-                terr = False
-                tfind, tid = self.photos_find_tag(
-                    photo_id=f[0],
-                    intag='album:{}'.format(f[2]
-                                            if f[2] is not None
-                                            else setName))
-                NP.niceprint('Found:[{!s}] TagId:[{!s}]'
+            tfind, tid = self.photos_find_tag(
+                photo_id=f[0],
+                intag='album:{}'.format(f[2]
+                                        if f[2] is not None
+                                        else setName))
+
+            logging.warning('       Find Tag:[%s] TagId:[%s]',
+                            tfind, tid)
+            if self.args.verbose:
+                NP.niceprint('       Find Tag::[{!s}] TagId:[{!s}]'
                              .format(tfind, tid))
-            except (flickrapi.exceptions.FlickrError, Exception) as ex:
-                niceerror(caught=True,
-                          caughtprefix='+++',
-                          caughtcode='212',
-                          caughtmsg='Exception on photos_find_tag',
-                          exceptuse=True,
-                          # exceptcode=ex.code,
-                          exceptmsg=ex,
-                          useniceprint=False,
-                          exceptsysinfo=True)
 
-                logging.warning('Error processing Photo_id:[%s]. '
-                                'Continuing...', f[0])
-                NP.niceprint('Error processing Photo_id:[{!s}]. Continuing...'
-                             .format(str(f[0])),
-                             fname='addAlbumMigrate')
-
-                terr = True
-
-            if not terr and not tfind:
+            if not tfind:
                 get_success, res_add_tag, get_errcode = faw.flickrapi_fn(
                     self.nuflickr.photos.addTags, (),
                     dict(photo_id=f[0],
@@ -3330,6 +3314,25 @@ class Uploadr(object):
                                                   if f[2] is not None
                                                   else setName)),
                     2, 2, False, caughtcode='214')
+
+                a_result = get_success and get_errcode == 0
+                logging.warning('%s: Photo_id:[%s]. ',
+                                'Added album tag'
+                                if a_result
+                                else 'Failed tagging',
+                                str(row[0]))
+                NP.niceprint('{!s}: Photo_id:[{!s}]. '
+                             .format(' Failed tagging'
+                                     if a_result
+                                     else 'Failed tagging',
+                                     str(row[0])),
+                             fname='addAlbumMigrate')
+            else:
+                logging.warning('      Found Tag:[%s] TagId:[{%s]',
+                                tfind, tid)
+                if self.args.verbose:
+                    NP.niceprint('      Found Tag::[{!s}] TagId:[{!s}]'
+                                 .format(tfind, tid))
 
             logging.debug('===Multiprocessing=== in.mutex.acquire(w)')
             mutex.acquire()
@@ -3431,41 +3434,20 @@ class Uploadr(object):
                     setName = set_name_from_file(row[1],
                                                  self.xcfg.FILES_DIR,
                                                  self.xcfg.FULL_SET_NAME)
-                    try:
-                        terr = False
-                        tfind, tid = self.photos_find_tag(
-                            photo_id=row[0],
-                            intag='album:{}'.format(row[2]
-                                                    if row[2] is not None
-                                                    else setName))
-                        NP.niceprint('Found:[{!s}] TagId:[{!s}]'
+
+                    tfind, tid = self.photos_find_tag(
+                        photo_id=row[0],
+                        intag='album:{}'.format(row[2]
+                                                if row[2] is not None
+                                                else setName))
+
+                    logging.warning('       Find Tag:[%s] TagId:[%s]',
+                                    tfind, tid)
+                    if self.args.verbose:
+                        NP.niceprint('       Find Tag::[{!s}] TagId:[{!s}]'
                                      .format(tfind, tid))
-                    except (flickrapi.exceptions.FlickrError, Exception) as ex:
-                        niceerror(caught=True,
-                                  caughtprefix='+++',
-                                  caughtcode='217',
-                                  caughtmsg='Exception on photos_find_tag',
-                                  exceptuse=True,
-                                  # exceptcode=ex.code,
-                                  exceptmsg=ex,
-                                  useniceprint=False,
-                                  exceptsysinfo=True)
 
-                        logging.warning('Error processing Photo_id:[%s]. '
-                                        'Continuing...',
-                                        str(row[0]))
-                        NP.niceprint('Error processing Photo_id:[{!s}]. '
-                                     'Continuing...'
-                                     .format(str(row[0])),
-                                     fname='addAlbumMigrate')
-
-                        terr = True
-
-                        NP.niceprocessedfiles(count, countTotal, False)
-
-                        continue
-
-                    if not terr and not tfind:
+                    if not tfind:
                         get_success, res_add_tag, get_errcode = \
                             faw.flickrapi_fn(
                                 self.nuflickr.photos.addTags, (),
@@ -3475,6 +3457,25 @@ class Uploadr(object):
                                              if row[2] is not None
                                              else setName)),
                                 2, 2, False, caughtcode='218')
+
+                        a_result = get_success and get_errcode == 0
+                        logging.warning('%s: Photo_id:[%s]. ',
+                                        'Added album tag'
+                                        if a_result
+                                        else 'Failed tagging',
+                                        str(row[0]))
+                        NP.niceprint('{!s}: Photo_id:[{!s}]. '
+                                     .format(' Failed tagging'
+                                             if a_result
+                                             else 'Failed tagging',
+                                             str(row[0])),
+                                     fname='addAlbumMigrate')
+                    else:
+                        logging.warning('      Found Tag:[%s] TagId:[{%s]',
+                                        tfind, tid)
+                        if self.args.verbose:
+                            NP.niceprint('      Found Tag::[{!s}] TagId:[{!s}]'
+                                         .format(tfind, tid))
 
                     NP.niceprocessedfiles(count, countTotal, False)
 

--- a/lib/FlickrUploadr.py
+++ b/lib/FlickrUploadr.py
@@ -1763,26 +1763,26 @@ class Uploadr(object):
 
                     if isGood(replaceResp):
                         # Update checksum tag at this time.
-      
+
                         get_success, res_add_tag, get_errcode = \
                             faw.flickrapi_fn(
                                 self.nuflickr.photos.addTags, (),
                                 dict(photo_id=file_id,
                                      tags='checksum:{}'.format(fileMd5)),
                                 2, 2, False, caughtcode='998')
-                        
+
                         if get_success and get_errcode == 0:
                             # Gets Flickr file info to obtain all tags
-                            # in order to update checksum tag if exists                            
+                            # in order to update checksum tag if exists
                             gi_success, res_get_info, gi_errcode = \
                                 faw.flickrapi_fn(
                                     self.nuflickr.photos.getInfo, (),
                                     dict(photo_id=file_id),
                                     2, 2, False, caughtcode='999')
-                            
+
                             if gi_success and gi_errcode == 0:
                                 # find tag checksum with oldFileMd5
-                                # later use such tag_id to delete it                                
+                                # later use such tag_id to delete it
                                 tag_id = None
                                 for tag in res_get_info\
                                     .find('photo')\
@@ -3266,13 +3266,13 @@ class Uploadr(object):
             The tag to remove from the photo. This parameter should contain
             a tag id, as returned by flickr.photos.getInfo.
         """
-        
+
         logging.info('remove_tag: tag_id:[%s]', tag_id)
-        
+
         get_success, get_result, getg_errcode = faw.flickrapi_fn(
             self.nuflickr.tags.removeTag, (),
             dict(tag_id=tag_id),
-            3, 5, False, caughtcode='206')        
+            3, 5, False, caughtcode='206')
 
         return get_result
 

--- a/lib/FlickrUploadr.py
+++ b/lib/FlickrUploadr.py
@@ -2049,7 +2049,8 @@ class Uploadr(object):
             self.nuflickr.photos.delete,
             (),
             dict(photo_id=str(file[0])),
-            2, 2, False)
+            2, 2, False,
+            caughtcode='999')
 
         success = False
         if ((get_success and get_errcode == 0) or
@@ -2389,7 +2390,8 @@ class Uploadr(object):
             (),
             dict(photoset_id=str(setId),
                  photo_id=str(file[0])),
-            2, 0, False)
+            2, 0, False,
+            caughtcode='999')
 
         success = False
         if get_success and get_errcode == 0:
@@ -2483,7 +2485,8 @@ class Uploadr(object):
             (),
             dict(title=setName,
                  primary_photo_id=str(primaryPhotoId)),
-            3, 10, True)
+            3, 10, True,
+            caughtcode='999')
 
         success = False
         if get_success and get_errcode == 0:

--- a/lib/MyConfig.py
+++ b/lib/MyConfig.py
@@ -86,7 +86,7 @@ class MyConfig(object):
     # Config section ----------------------------------------------------------
     INISections = ['Config']
     # Default configuration keys/values pairs ---------------------------------
-    INIkeys = [
+    ini_keys = [
         'FILES_DIR',
         'FLICKR',
         'SLEEP_TIME',
@@ -192,7 +192,7 @@ class MyConfig(object):
         """
 
         # Assume default values into class dictionary of values ---------------
-        self.__dict__ = dict(zip(self.INIkeys, self.INIvalues))
+        self.__dict__ = dict(zip(self.ini_keys, self.INIvalues))
 
         if logging.getLogger().getEffectiveLevel() <= logging.DEBUG:
             logging.debug('\t\t\t\tDefault INI key/values pairs...')
@@ -230,7 +230,7 @@ class MyConfig(object):
 
             # Find incorrect config keys on INI File and delete them
             dropkeys = [key for key in self.__dict__.keys()
-                        if key not in self.INIkeys]
+                        if key not in self.ini_keys]
             logging.debug('dropkeys:[%s]', dropkeys)
             for key in dropkeys:
                 logging.debug('del key:[%s]', key)
@@ -267,7 +267,7 @@ class MyConfig(object):
             Evaluates configuration items. Uses default values if not valid.
         """
         # Default types for keys/values pairs ---------------------------------
-        INItypes = [
+        ini_types = [
             'str',   # 'FILES_DIR',
             'dict',  # 'FLICKR',
             'int',   # 'SLEEP_TIME',
@@ -294,14 +294,14 @@ class MyConfig(object):
             'int',   # ROTATING_LOGGING_FILE_COUNT,
             'int'    # ROTATING_LOGGING_LEVEL
         ]
-        INIcheck = dict(zip(self.INIkeys, INItypes))
+        ini_check = dict(zip(self.ini_keys, ini_types))
         if logging.getLogger().getEffectiveLevel() <= logging.INFO:
             logging.debug('\t\t\t\tDefault INI key/type pairs...')
-            for item in sorted(INIcheck):
+            for item in sorted(ini_check):
                 logging.debug('[{!s:20s}]/type:[{!s:13s}] = [{!s:10s}]'
                               .format(item,
-                                      type(INIcheck[item]),
-                                      self.strunicodeout(INIcheck[item])))
+                                      type(ini_check[item]),
+                                      self.strunicodeout(ini_check[item])))
         # Evaluate values
         for item in sorted(self.__dict__):
             logging.debug('Eval for : [{!s:20s}]/type:[{!s:13s}] = [{!s:10s}]'
@@ -310,12 +310,12 @@ class MyConfig(object):
                                   self.strunicodeout(self.__dict__[item])))
 
             try:
-                if INIcheck[item] in ('list', 'int', 'bool', 'str', 'dict'):
+                if ini_check[item] in ('list', 'int', 'bool', 'str', 'dict'):
                     logging.debug('isinstance=%s',
                                   isinstance(eval(self.__dict__[item]),
-                                             eval(INIcheck[item])))
+                                             eval(ini_check[item])))
                     if not(isinstance(eval(self.__dict__[item]),
-                                      eval(INIcheck[item]))):
+                                      eval(ini_check[item]))):
                         raise
                 else:
                     raise
@@ -323,17 +323,17 @@ class MyConfig(object):
                 self.niceerror(caught=True,
                                caughtprefix='+++ ',
                                caughtcode='800',
-                               caughtmsg='Caught an exception INIcheck',
+                               caughtmsg='Caught an exception ini_check',
                                exceptsysinfo=True)
-                logging.critical('Invalid INI value for:[%s] '
-                                 'Using default value:[%s]',
-                                 item,
-                                 self.INIvalues[self.INIkeys.index(str(item))])
+                logging.critical(
+                    'Invalid INI value for:[%s] Using default value:[%s]',
+                    item,
+                    self.INIvalues[self.ini_keys.index(str(item))])
                 # Using default value to avoid exiting.
                 # Use verifyconfig  to confirm valid values.
                 self.__dict__.update(dict(zip(
                     [item],
-                    [self.INIvalues[self.INIkeys.index(str(item))]])))
+                    [self.INIvalues[self.ini_keys.index(str(item))]])))
             finally:
                 self.__dict__[item] = eval(self.__dict__[item])
                 logging.debug('Eval done: [{!s:20s}]/type:[{!s:13s}] '

--- a/lib/MyConfig.py
+++ b/lib/MyConfig.py
@@ -435,7 +435,7 @@ class MyConfig(object):
                         if sys.version_info < (3, ) \
                         else str(self.__dict__[item])
 
-                if ((len(os.path.dirname(self.__dict__[item])) > 0) and
+                if (len(os.path.dirname(self.__dict__[item])) and
                         not os.path.isdir(
                             os.path.dirname(self.__dict__[item]))):
                     logging.critical('%s:[%s] is not in a valid folder:[%s].',
@@ -464,7 +464,7 @@ class MyConfig(object):
                             if sys.version_info < (3, ) \
                             else str(self.__dict__[item])
 
-                    if (len(os.path.dirname(self.__dict__[item])) > 0 and
+                    if (len(os.path.dirname(self.__dict__[item])) and
                             not os.path.isdir(
                                 os.path.dirname(self.__dict__[item]))):
                         logging.critical('%s:[%s] is not in '

--- a/lib/MyConfig.py
+++ b/lib/MyConfig.py
@@ -577,7 +577,7 @@ class MyConfig(object):
             returnverify = False
         elif not verify_paths():
             returnverify = False
-        elif not verify_rotating_path()
+        elif not verify_rotating_path():
             returnverify = False
         elif not verify_raw_files():
             returnverify = False

--- a/lib/MyConfig.py
+++ b/lib/MyConfig.py
@@ -263,6 +263,8 @@ class MyConfig(object):
     #
     def processconfig(self):
         """ processconfig
+
+            Evaluates configuration items. Uses default values if not valid.
         """
         # Default types for keys/values pairs ---------------------------------
         INItypes = [
@@ -357,10 +359,14 @@ class MyConfig(object):
     #
     def verifyconfig(self):
         """ verifyconfig
+
+            Verifies configuration. Must be called after processconfig().
         """
 
         def verify_logging_level():
             """ verify_logging_level
+
+                Verifies Logging related option is set to a valid value.
             """
 
             # Further specific processing... LOGGING_LEVELs
@@ -381,11 +387,14 @@ class MyConfig(object):
 
         def verify_files_dir():
             """ verify_files_dir
+
+                Checks folder is valid and exists.
             """
 
             result = True
             # Further specific processing... FILES_DIR
             for item in ['FILES_DIR']:  # Check if dir exists. Unicode Support
+
                 logging.debug('verifyconfig for [%s]', item)
                 if not self.is_str_unicode(self.__dict__[item]):
                     self.__dict__[item] = unicode(  # noqa
@@ -393,17 +402,19 @@ class MyConfig(object):
                         'utf-8') \
                         if sys.version_info < (3, ) \
                         else str(self.__dict__[item])
+
                 if not os.path.isdir(self.__dict__[item]):
                     logging.critical('%s: [%s] is not a valid folder.',
                                      item,
                                      self.strunicodeout(self.__dict__[item]))
                     result = False
+
             return result
 
         def verify_paths():
             """ verify_paths
 
-                Further specific verification processing...
+                Checks parent folder for item (file) is valid and exists for:
                       DB_PATH
                       LOCK_PATH
                       TOKEN_CACHE
@@ -414,8 +425,8 @@ class MyConfig(object):
             for item in ['DB_PATH',  # Check if basedir exists. Unicode Support
                          'LOCK_PATH',
                          'TOKEN_CACHE',
-                         'TOKEN_PATH',
-                         'ROTATING_LOGGING_PATH']:
+                         'TOKEN_PATH']:
+
                 logging.debug('verifyconfig for [%s]', item)
                 if not self.is_str_unicode(self.__dict__[item]):
                     self.__dict__[item] = unicode(  # noqa
@@ -423,6 +434,7 @@ class MyConfig(object):
                         'utf-8') \
                         if sys.version_info < (3, ) \
                         else str(self.__dict__[item])
+
                 if (len(os.path.dirname(self.__dict__[item])) > 0 and
                         not os.path.isdir(
                             os.path.dirname(self.__dict__[item]))):
@@ -432,6 +444,37 @@ class MyConfig(object):
                                      self.strunicodeout(os.path.dirname(
                                          self.__dict__[item])))
                     result = False
+            return result
+
+        def verify_rotating_path():
+            """ verify_rotating_path
+
+                Checks parent folder for item (file) is valid and exists.
+                      ROTATING_LOGGING_PATH
+            """
+
+            result = True
+            if self.__dict__['ROTATING_LOGGING']:
+                for item in ['ROTATING_LOGGING_PATH']:
+                    logging.debug('verifyconfig for [%s]', item)
+                    if not self.is_str_unicode(self.__dict__[item]):
+                        self.__dict__[item] = unicode(  # noqa
+                            self.__dict__[item],
+                            'utf-8') \
+                            if sys.version_info < (3, ) \
+                            else str(self.__dict__[item])
+
+                    if (len(os.path.dirname(self.__dict__[item])) > 0 and
+                            not os.path.isdir(
+                                os.path.dirname(self.__dict__[item]))):
+                        logging.critical('%s:[%s] is not in '
+                                         'a valid folder:[%s].',
+                                         item,
+                                         self.strunicodeout(
+                                             self.__dict__[item]),
+                                         self.strunicodeout(os.path.dirname(
+                                             self.__dict__[item])))
+                        result = False
             return result
 
         def verify_raw_files():
@@ -533,6 +576,8 @@ class MyConfig(object):
         elif not verify_files_dir():
             returnverify = False
         elif not verify_paths():
+            returnverify = False
+        elif not verify_rotating_path()
             returnverify = False
         elif not verify_raw_files():
             returnverify = False

--- a/lib/MyConfig.py
+++ b/lib/MyConfig.py
@@ -435,7 +435,7 @@ class MyConfig(object):
                         if sys.version_info < (3, ) \
                         else str(self.__dict__[item])
 
-                if (len(os.path.dirname(self.__dict__[item])) and
+                if (os.path.dirname(self.__dict__[item]) and
                         not os.path.isdir(
                             os.path.dirname(self.__dict__[item]))):
                     logging.critical('%s:[%s] is not in a valid folder:[%s].',
@@ -464,7 +464,7 @@ class MyConfig(object):
                             if sys.version_info < (3, ) \
                             else str(self.__dict__[item])
 
-                    if (len(os.path.dirname(self.__dict__[item])) and
+                    if (os.path.dirname(self.__dict__[item]) and
                             not os.path.isdir(
                                 os.path.dirname(self.__dict__[item]))):
                         logging.critical('%s:[%s] is not in '

--- a/lib/MyConfig.py
+++ b/lib/MyConfig.py
@@ -435,7 +435,7 @@ class MyConfig(object):
                         if sys.version_info < (3, ) \
                         else str(self.__dict__[item])
 
-                if (len(os.path.dirname(self.__dict__[item])) > 0 and
+                if ((len(os.path.dirname(self.__dict__[item])) > 0) and
                         not os.path.isdir(
                             os.path.dirname(self.__dict__[item]))):
                     logging.critical('%s:[%s] is not in a valid folder:[%s].',

--- a/lib/MyConfig.py
+++ b/lib/MyConfig.py
@@ -107,6 +107,7 @@ class MyConfig(object):
         'MAX_SQL_ATTEMPTS',
         'MAX_UPLOAD_ATTEMPTS',
         'LOGGING_LEVEL',
+        'ROTATING_LOGGING',
         'ROTATING_LOGGING_PATH',
         'ROTATING_LOGGING_FILE_SIZE',
         'ROTATING_LOGGING_FILE_COUNT',
@@ -169,6 +170,8 @@ class MyConfig(object):
         "10",
         # LOGGING_LEVEL (30 = logging.ERROR). Note: Affects doctests results
         "40",
+        # ROTATING_LOGGING
+        "False",
         # ROTATING_LOGGING_PATH
         "os.path.join(os.path.dirname(sys.argv[0]), 'uploadr.err')",
         # ROTATING_LOGGING_FILE_SIZE
@@ -283,6 +286,7 @@ class MyConfig(object):
             'int',   # 'MAX_SQL_ATTEMPTS',
             'int',   # 'MAX_UPLOAD_ATTEMPTS',
             'int',   # 'LOGGING_LEVEL',
+            'bool',  # ROTATING_LOGGING
             'str',   # ROTATING_LOGGING_PATH,
             'int',   # ROTATING_LOGGING_FILE_SIZE,
             'int',   # ROTATING_LOGGING_FILE_COUNT,

--- a/lib/MyConfig.py
+++ b/lib/MyConfig.py
@@ -286,7 +286,7 @@ class MyConfig(object):
             'str',   # ROTATING_LOGGING_PATH,
             'int',   # ROTATING_LOGGING_FILE_SIZE,
             'int',   # ROTATING_LOGGING_FILE_COUNT,
-            'int'    # ROTATING_LOGGING_LEVEL        
+            'int'    # ROTATING_LOGGING_LEVEL
         ]
         INIcheck = dict(zip(self.INIkeys, INItypes))
         if logging.getLogger().getEffectiveLevel() <= logging.INFO:
@@ -369,7 +369,7 @@ class MyConfig(object):
                          logging.ERROR,
                          logging.CRITICAL]:
                     self.__dict__[level] = logging.ERROR
-                # Convert LOGGING_LEVEL into int() for later use in conditionals
+                # Convert LOGGING_LEVEL into int() for use in conditionals
                 self.__dict__[level] = int(str(
                     self.__dict__[level]))
 

--- a/lib/MyConfig.py
+++ b/lib/MyConfig.py
@@ -380,8 +380,7 @@ class MyConfig(object):
                          logging.CRITICAL]:
                     self.__dict__[level] = logging.ERROR
                 # Convert LOGGING_LEVEL into int() for use in conditionals
-                self.__dict__[level] = int(str(
-                    self.__dict__[level]))
+                self.__dict__[level] = int(str(self.__dict__[level]))
 
             return True
 

--- a/lib/NicePrint.py
+++ b/lib/NicePrint.py
@@ -19,7 +19,7 @@ import os
 import logging
 import time
 import lib.UPLDRConstants as UPLDRConstantsClass
-UPLDRConstants = UPLDRConstantsClass.UPLDRConstants()
+UPLDR_K = UPLDRConstantsClass.UPLDRConstants()
 
 
 # -----------------------------------------------------------------------------
@@ -118,11 +118,11 @@ class NicePrint:
 
         """
         print('{}[{!s}][{!s}]:[{!s:11s}]{}[{!s:8s}]:[{!s}] {!s}'
-              .format(UPLDRConstants.Gre,
-                      UPLDRConstants.Run,
-                      time.strftime(UPLDRConstants.TimeFormat),
+              .format(UPLDR_K.Gre,
+                      UPLDR_K.Run,
+                      time.strftime(UPLDR_K.TimeFormat),
                       os.getpid(),
-                      UPLDRConstants.Std,
+                      UPLDR_K.Std,
                       'PRINT',
                       self.strunicodeout(fname),
                       self.strunicodeout(astr)))
@@ -141,11 +141,11 @@ class NicePrint:
                                             .format(param1))
         """
         return('{}[{!s}][{!s}]:[{!s:11s}]{}[{!s:8s}]:[{!s}] {!s}'
-               .format(UPLDRConstants.Red,
-                       UPLDRConstants.Run,
-                       time.strftime(UPLDRConstants.TimeFormat),
+               .format(UPLDR_K.Red,
+                       UPLDR_K.Run,
+                       time.strftime(UPLDR_K.TimeFormat),
                        os.getpid(),
-                       UPLDRConstants.Std,
+                       UPLDR_K.Std,
                        'ASSERT',
                        'uploadr',
                        self.strunicodeout(astr)))

--- a/lib/NicePrint.py
+++ b/lib/NicePrint.py
@@ -118,11 +118,11 @@ class NicePrint:
 
         """
         print('{}[{!s}][{!s}]:[{!s:11s}]{}[{!s:8s}]:[{!s}] {!s}'
-              .format(UPLDRConstants.G,
+              .format(UPLDRConstants.Gre,
                       UPLDRConstants.Run,
                       time.strftime(UPLDRConstants.TimeFormat),
                       os.getpid(),
-                      UPLDRConstants.W,
+                      UPLDRConstants.Std,
                       'PRINT',
                       self.strunicodeout(fname),
                       self.strunicodeout(astr)))
@@ -141,11 +141,11 @@ class NicePrint:
                                             .format(param1))
         """
         return('{}[{!s}][{!s}]:[{!s:11s}]{}[{!s:8s}]:[{!s}] {!s}'
-               .format(UPLDRConstants.R,
+               .format(UPLDRConstants.Red,
                        UPLDRConstants.Run,
                        time.strftime(UPLDRConstants.TimeFormat),
                        os.getpid(),
-                       UPLDRConstants.W,
+                       UPLDRConstants.Std,
                        'ASSERT',
                        'uploadr',
                        self.strunicodeout(astr)))

--- a/lib/UPLDRConstants.py
+++ b/lib/UPLDRConstants.py
@@ -55,12 +55,12 @@ class UPLDRConstants:
 
     # -------------------------------------------------------------------------
     # Color Codes for colorful output
-    W = '\033[0m'    # white (normal)
-    R = '\033[31m'   # red
-    G = '\033[32m'   # green
-    Or = '\033[33m'   # orange
-    B = '\033[34m'   # blue
-    P = '\033[35m'   # purple
+    Std = '\033[0m'    # white (standard/normal)
+    Red = '\033[31m'   # red
+    Gre = '\033[32m'   # green
+    Ora = '\033[33m'   # orange
+    Blu = '\033[34m'   # blue
+    Pur = '\033[35m'   # purple
 
     # -------------------------------------------------------------------------
     # class UPLDRConstants __init__

--- a/lib/__version__.py
+++ b/lib/__version__.py
@@ -5,6 +5,6 @@
     __version__ = Semantic Versioning number Major.Minor.Patch
                   Check https://semver.org
 """
-VERSION = (2, 8, 1)
+VERSION = (2, 8, 5)
 
 __version__ = '.'.join(map(str, VERSION))

--- a/lib/mprocessing.py
+++ b/lib/mprocessing.py
@@ -24,13 +24,13 @@ import lib.NicePrint as NicePrint
 # mprocessing
 #
 def mprocessing(args_verbose, args_verbose_progress,
-                nprocs, lockDB, running, mutex, itemslist, a_fn, cur):
+                nprocs, lockdb, running, mutex, itemslist, a_fn, cur):
     """ mprocessing Function
 
     verbose          = verbose info
     verbose_progress = further verbose
     nprocs           = Number of processes to launch
-    lockDB           = lock for access to Database
+    lockdb           = lock for access to Database
     running          = Value to count processed items
     mutex            = mutex for access to value running
     itemslist        = list of items to be processed
@@ -89,7 +89,7 @@ def mprocessing(args_verbose, args_verbose_progress,
         return iter(lambda: tuple(islice(iter_list, size)), ())
 
     proc_pool = []
-    lockDB = multiprocessing.Lock()
+    lockdb = multiprocessing.Lock()
     running = multiprocessing.Value('i', 0)
     mutex = multiprocessing.Lock()
     count_total = len(itemslist)
@@ -113,7 +113,7 @@ def mprocessing(args_verbose, args_verbose_progress,
         logging.debug('===Job/Task Process: Creating...')
         proc_task = multiprocessing.Process(
             target=a_fn,  # argument function
-            args=(lockDB,
+            args=(lockdb,
                   running,
                   mutex,
                   splititemslist,
@@ -177,15 +177,15 @@ def mprocessing(args_verbose, args_verbose_progress,
     logging.warning('===Multiprocessing=== pool joined! '
                     'All processes finished.')
 
-    # Will release (set to None) the nulockDB lock control
+    # Will release (set to None) the lockdb lock control
     # this prevents subsequent calls to
     # useDBLock( nuLockDB, False)
     # to raise exception:
     #   ValueError('semaphore or lock released too many times')
     logging.info('===Multiprocessing=== pool joined! '
-                 'Is lockDB  None? [%s]. Setting lockDB to None anyhow.',
-                 lockDB is None)
-    lockDB = None
+                 'Is lockdb  None? [%s]. Setting lockdb to None anyhow.',
+                 lockdb is None)
+    lockdb = None
 
     # Show number of total files processed
     npr.niceprocessedfiles(running.value, count_total, True)

--- a/lib/rate_limited.py
+++ b/lib/rate_limited.py
@@ -194,7 +194,7 @@ def rate_limited(max_per_second):
             except Exception as ex:
                 NPR.niceerror(caught=True,
                               caughtprefix='+++Rate',
-                              caughtcode='000',
+                              caughtcode='001',
                               caughtmsg='Exception on rate_limited_function',
                               exceptuse=True,
                               # exceptCode=ex.code,

--- a/lib/rate_limited.py
+++ b/lib/rate_limited.py
@@ -193,7 +193,7 @@ def rate_limited(max_per_second):
 
             except Exception as ex:
                 NPR.niceerror(caught=True,
-                              caughtprefix='+++',
+                              caughtprefix='+++Rate',
                               caughtcode='000',
                               caughtmsg='Exception on rate_limited_function',
                               exceptuse=True,

--- a/tests/TestModules.py
+++ b/tests/TestModules.py
@@ -125,12 +125,12 @@ class TestUPLDRConstantsMethods(unittest.TestCase):
 if __name__ == '__main__':
     # unittest.main()
 
-    suite = unittest.TestLoader().loadTestsFromTestCase(TestMethods)
-    unittest.TextTestRunner(verbosity=2).run(suite)
+    SUITE = unittest.TestLoader().loadTestsFromTestCase(TestMethods)
+    unittest.TextTestRunner(verbosity=2).run(SUITE)
 
-    suite = unittest.TestLoader().loadTestsFromTestCase(TestNicePrintMethods)
-    unittest.TextTestRunner(verbosity=2).run(suite)
+    SUITE = unittest.TestLoader().loadTestsFromTestCase(TestNicePrintMethods)
+    unittest.TextTestRunner(verbosity=2).run(SUITE)
 
-    suite = unittest.TestLoader().loadTestsFromTestCase(
+    SUITE = unittest.TestLoader().loadTestsFromTestCase(
         TestUPLDRConstantsMethods)
-    unittest.TextTestRunner(verbosity=2).run(suite)
+    unittest.TextTestRunner(verbosity=2).run(SUITE)

--- a/tests/TestModules.py
+++ b/tests/TestModules.py
@@ -115,11 +115,11 @@ class TestUPLDRConstantsMethods(unittest.TestCase):
     def test_media_count(self):
         """ test_media_count
         """
-        UPLDR_K = UPLDRConstantsClass.UPLDRConstants()
+        upldr_k = UPLDRConstantsClass.UPLDRConstants()
 
         for j in range(1, 20):
-            UPLDR_K.media_count = j
-            self.assertEqual(UPLDR_K.media_count, j)
+            upldr_k.media_count = j
+            self.assertEqual(upldr_k.media_count, j)
 
 
 if __name__ == '__main__':

--- a/tests/TestModules.py
+++ b/tests/TestModules.py
@@ -38,7 +38,7 @@ class TestNicePrintMethods(unittest.TestCase):
 
         print(astr.getvalue())
         print('type:{}'.format(type(astr)))
-        npre = '\[[0-9. :]+\].+hello$'
+        npre = r'\[[0-9. :]+\].+hello$'
         self.assertRegexpMatches(astr.getvalue(), npre)
 
     def test_unicode(self):
@@ -115,11 +115,11 @@ class TestUPLDRConstantsMethods(unittest.TestCase):
     def test_media_count(self):
         """ test_media_count
         """
-        UPLDRConstants = UPLDRConstantsClass.UPLDRConstants()
+        UPLDR_K = UPLDRConstantsClass.UPLDRConstants()
 
         for j in range(1, 20):
-            UPLDRConstants.media_count = j
-            self.assertEqual(UPLDRConstants.media_count, j)
+            UPLDR_K.media_count = j
+            self.assertEqual(UPLDR_K.media_count, j)
 
 
 if __name__ == '__main__':

--- a/tests/drop.py
+++ b/tests/drop.py
@@ -133,7 +133,7 @@ if __name__ == '__main__':
     # Check that the access token is valid
     try:
         DBX.users_get_current_account()
-    except AuthError as err:
+    except AuthError:
         sys.exit("ERROR: Invalid access token; try re-generating an "
                  "access token from the app console on the web.")
 

--- a/tests/uploadr.ini
+++ b/tests/uploadr.ini
@@ -125,6 +125,22 @@ MAX_UPLOAD_ATTEMPTS = 10
 LOGGING_LEVEL = 20
 
 ################################################################################
+#   Output logging information into a rotating set of log file(s).
+#       ROTATING_LOGGING to Enable/Disable
+#       ROTATING_LOGGING_PATH location of folder/main logging filename
+#       ROTATING_LOGGING_FILE_SIZE for maximum file size of each log file
+#       ROTATING_LOGGING_FILE_COUNT for maximum count of old log files to keep
+#       ROTATING_LOGGING_LEVEL Level Logging 
+#           Check LOGGING_LEVEL setting for options.
+#           Normally set ROTATING_LOGGING_LEVELto lower than LOGGING_LEVEL
+################################################################################
+ROTATING_LOGGING = False
+ROTATING_LOGGING_PATH = os.path.join(os.getcwd(), "uploadr.err")
+ROTATING_LOGGING_FILE_SIZE = 25*1024*1024  # 25 MBytes
+ROTATING_LOGGING_FILE_COUNT = 3
+ROTATING_LOGGING_LEVEL = 10
+
+################################################################################
 # Wrong value to be eliminated and ignored if test succsessful
 ################################################################################
 WRONG_VALUE_FOR_TESTING = 100

--- a/tests/uploadr_NoVerbose.ini
+++ b/tests/uploadr_NoVerbose.ini
@@ -125,6 +125,22 @@ MAX_UPLOAD_ATTEMPTS = 10
 LOGGING_LEVEL = 40
 
 ################################################################################
+#   Output logging information into a rotating set of log file(s).
+#       ROTATING_LOGGING to Enable/Disable
+#       ROTATING_LOGGING_PATH location of folder/main logging filename
+#       ROTATING_LOGGING_FILE_SIZE for maximum file size of each log file
+#       ROTATING_LOGGING_FILE_COUNT for maximum count of old log files to keep
+#       ROTATING_LOGGING_LEVEL Level Logging 
+#           Check LOGGING_LEVEL setting for options.
+#           Normally set ROTATING_LOGGING_LEVELto lower than LOGGING_LEVEL
+################################################################################
+ROTATING_LOGGING = True
+ROTATING_LOGGING_PATH = os.path.join(os.getcwd(), "uploadr.err")
+ROTATING_LOGGING_FILE_SIZE = 25*1024*1024  # 25 MBytes
+ROTATING_LOGGING_FILE_COUNT = 3
+ROTATING_LOGGING_LEVEL = 10
+
+################################################################################
 # Wrong value to be eliminated and ignored if test succsessful
 ################################################################################
 WRONG_VALUE_FOR_TESTING = 100

--- a/tests/uploadr_excluded.ini
+++ b/tests/uploadr_excluded.ini
@@ -123,3 +123,19 @@ MAX_UPLOAD_ATTEMPTS = 10
 # NOTSET	0
 ################################################################################
 LOGGING_LEVEL = 10
+
+################################################################################
+#   Output logging information into a rotating set of log file(s).
+#       ROTATING_LOGGING to Enable/Disable
+#       ROTATING_LOGGING_PATH location of folder/main logging filename
+#       ROTATING_LOGGING_FILE_SIZE for maximum file size of each log file
+#       ROTATING_LOGGING_FILE_COUNT for maximum count of old log files to keep
+#       ROTATING_LOGGING_LEVEL Level Logging 
+#           Check LOGGING_LEVEL setting for options.
+#           Normally set ROTATING_LOGGING_LEVELto lower than LOGGING_LEVEL
+################################################################################
+ROTATING_LOGGING = True
+ROTATING_LOGGING_PATH = os.path.join(os.getcwd(), "uploadr.err")
+ROTATING_LOGGING_FILE_SIZE = 25*1024*1024  # 25 MBytes
+ROTATING_LOGGING_FILE_COUNT = 3
+ROTATING_LOGGING_LEVEL = 20

--- a/uploadr.ini
+++ b/uploadr.ini
@@ -125,9 +125,15 @@ MAX_UPLOAD_ATTEMPTS = 10
 LOGGING_LEVEL = 40
 
 ################################################################################
-#   Location of file where we keep the rotating log file(s)
+#   Output logging information into a rotating set of log file(s).
+#       ROTATING_LOGGING to Enable/Disable
+#       ROTATING_LOGGING_PATH location of folder/main logging filename
+#       ROTATING_LOGGING_FILE_SIZE for maximum file size of each log file
+#       ROTATING_LOGGING_FILE_COUNT for maximum count of old log files to keep
+#       ROTATING_LOGGING_LEVEL Level Logging (check LOGGING_LEVEL setting)
 ################################################################################
-ROTATING_LOGGING_PATH = os.path.join(os.path.dirname(sys.argv[0]), "uploadr.err")
+ROTATING_LOGGING = False
+ROTATING_LOGGING_PATH = os.path.join(os.path.dirname(sys.argv[0]), "logs", "uploadr.err")
 ROTATING_LOGGING_FILE_SIZE = 25*1024*1024  # 25 MBytes
 ROTATING_LOGGING_FILE_COUNT = 3
 ROTATING_LOGGING_LEVEL = 30

--- a/uploadr.ini
+++ b/uploadr.ini
@@ -123,3 +123,11 @@ MAX_UPLOAD_ATTEMPTS = 10
 # NOTSET	0
 ################################################################################
 LOGGING_LEVEL = 40
+
+################################################################################
+#   Location of file where we keep the rotating log file(s)
+################################################################################
+ROTATING_LOGGING_PATH = os.path.join(os.path.dirname(sys.argv[0]), "uploadr.err")
+ROTATING_LOGGING_FILE_SIZE = 25*1024*1024  # 25 MBytes
+ROTATING_LOGGING_FILE_COUNT = 3
+ROTATING_LOGGING_LEVEL = 30

--- a/uploadr.ini
+++ b/uploadr.ini
@@ -130,7 +130,9 @@ LOGGING_LEVEL = 40
 #       ROTATING_LOGGING_PATH location of folder/main logging filename
 #       ROTATING_LOGGING_FILE_SIZE for maximum file size of each log file
 #       ROTATING_LOGGING_FILE_COUNT for maximum count of old log files to keep
-#       ROTATING_LOGGING_LEVEL Level Logging (check LOGGING_LEVEL setting)
+#       ROTATING_LOGGING_LEVEL Level Logging 
+#           Check LOGGING_LEVEL setting for options.
+#           Normally set ROTATING_LOGGING_LEVELto lower than LOGGING_LEVEL
 ################################################################################
 ROTATING_LOGGING = False
 ROTATING_LOGGING_PATH = os.path.join(os.path.dirname(sys.argv[0]), "logs", "uploadr.err")

--- a/uploadr.py
+++ b/uploadr.py
@@ -89,8 +89,8 @@ logging.getLogger().setLevel(logging.DEBUG)
 CONSOLE_LOGGING = logging.StreamHandler()
 CONSOLE_LOGGING.setLevel(logging.WARNING)
 CONSOLE_LOGGING.setFormatter(logging.Formatter(
-    fmt=UPLDRConstants.P + '[' + str(UPLDRConstants.Run) + ']' +
-    '[%(asctime)s]:[%(processName)-11s]' + UPLDRConstants.W +
+    fmt=UPLDRConstants.Pur + '[' + str(UPLDRConstants.Run) + ']' +
+    '[%(asctime)s]:[%(processName)-11s]' + UPLDRConstants.Std +
     '[%(levelname)-8s]:[%(name)s] %(message)s',
     datefmt=UPLDRConstants.TimeFormat))
 logging.getLogger().addHandler(CONSOLE_LOGGING)

--- a/uploadr.py
+++ b/uploadr.py
@@ -521,7 +521,8 @@ if __name__ == "__main__":
                 datefmt=UPLDRConstants.TimeFormat))
             logging.getLogger().addHandler(ROTATING_LOGGING)
 
-            logging.warning('----------- (V%s) Init Rotating -----------(Log:%s)\n'
+            logging.warning('----------- (V%s) Init Rotating '
+                            '-----------(Log:%s)\n'
                             'Python version on this system: [%s]',
                             UPLDRConstants.Version,
                             MY_CFG.LOGGING_LEVEL,

--- a/uploadr.py
+++ b/uploadr.py
@@ -133,7 +133,7 @@ def my_excepthook(exc_class, exc_value, exc_tb):
         Exception handler to be installed over sys.excepthook to allow
         traceback reporting information to be reported back to logging file
     """
-    logging.critical('Uncaught exception: %s: %s', exc_class, exc_value)
+    logging.critical('Exception: %s: %s', exc_class, exc_value)
     logging.critical('%s', ''.join(traceback.format_tb(exc_tb)))
 
 

--- a/uploadr.py
+++ b/uploadr.py
@@ -339,7 +339,7 @@ def run_uploadr(args):
     if args.clean_bad_files:
         myflick.cleanDBbadfiles()
 
-    if args.authentication:
+    if args.authenticate:
         NPR.niceprint('Checking if token is available... '
                       'if not will authenticate')
         if not myflick.check_token():

--- a/uploadr.py
+++ b/uploadr.py
@@ -195,12 +195,6 @@ def parse_arguments():
                             metavar='N', type=int,
                             help='List as many as N photos (with tags) '
                                  'not in set. Maximum listed photos is 500.')
-    # finds duplicated images (based on checksum, titlename, setName) in Flickr
-    igrpparser.add_argument('-z', '--search-for-duplicates',
-                            action='store_true',
-                            help='Lists duplicated files: same checksum, '
-                                 'same title, list SetName (if different). '
-                                 'Not operational at this time.')
 
     # Processing related options ----------------------------------------------
     pgrpparser = parser.add_argument_group('Processing related options')
@@ -379,9 +373,6 @@ def run_uploadr(args):
             myflick.getFlickrSets()
             myflick.upload()
             myflick.removeDeletedMedia()
-
-            if args.search_for_duplicates:
-                myflick.searchForDuplicates()
 
             if args.remove_excluded:
                 myflick.removeExcludedMedia()

--- a/uploadr.py
+++ b/uploadr.py
@@ -408,7 +408,7 @@ def check_base_ini_file(base_dir, ini_file):
         if not ((base_dir == '' or os.path.isdir(base_dir)) and
                 os.path.isfile(ini_file)):
             raise OSError('[Errno 2] No such file or directory')
-    except Exception as err:
+    except OSError as err:
         result_check = False
         logging.critical(
             'Config folder [%s] and/or INI file: [%s] not found or '

--- a/uploadr.py
+++ b/uploadr.py
@@ -81,7 +81,7 @@ import lib.MyConfig as MyConfig
 # Logging init code
 #
 # Getting definitions from UPLDRConstants
-UPLDRConstants = UPLDRConstantsClass.UPLDRConstants()
+UPLDR_K = UPLDRConstantsClass.UPLDRConstants()
 # Sets LOGGING_LEVEL to allow logging even if everything else is wrong!
 # Parent logger is set to Maximum (DEBUG) so that suns will log as appropriate
 logging.getLogger().setLevel(logging.DEBUG)
@@ -89,10 +89,10 @@ logging.getLogger().setLevel(logging.DEBUG)
 CONSOLE_LOGGING = logging.StreamHandler()
 CONSOLE_LOGGING.setLevel(logging.WARNING)
 CONSOLE_LOGGING.setFormatter(logging.Formatter(
-    fmt=UPLDRConstants.Pur + '[' + str(UPLDRConstants.Run) + ']' +
-    '[%(asctime)s]:[%(processName)-11s]' + UPLDRConstants.Std +
+    fmt=UPLDR_K.Pur + '[' + str(UPLDR_K.Run) + ']' +
+    '[%(asctime)s]:[%(processName)-11s]' + UPLDR_K.Std +
     '[%(levelname)-8s]:[%(name)s] %(message)s',
-    datefmt=UPLDRConstants.TimeFormat))
+    datefmt=UPLDR_K.TimeFormat))
 logging.getLogger().addHandler(CONSOLE_LOGGING)
 
 # Inits with default configuration value, namely LOGGING_LEVEL
@@ -113,14 +113,14 @@ if sys.version_info < (2, 7):
                      'This script requires Python 2.7 or newer.'
                      'Current Python version: [%s] '
                      'Exiting...',
-                     UPLDRConstants.Version,
+                     UPLDR_K.Version,
                      MY_CFG.LOGGING_LEVEL,
                      sys.version)
     sys.exit(1)
 else:
     logging.warning('----------- (V%s) Init -----------(Log:%s)'
                     'Python version on this system: [%s]',
-                    UPLDRConstants.Version,
+                    UPLDR_K.Version,
                     MY_CFG.LOGGING_LEVEL,
                     sys.version)
 # -----------------------------------------------------------------------------
@@ -161,7 +161,7 @@ def parse_arguments():
                             type=str,
                             help='Optional configuration file. '
                                  'Default is:[{!s}]'
-                            .format(UPLDRConstants.ini_file))
+                            .format(UPLDR_K.ini_file))
 
     # Verbose related options -------------------------------------------------
     vgrpparser = parser.add_argument_group('Verbose and dry-run options')
@@ -433,23 +433,23 @@ def check_base_ini_file(base_dir, ini_file):
 #   ini_file      = Configuration file
 # -----------------------------------------------------------------------------
 # UPLDRConstants = UPLDRConstantsClass.UPLDRConstants()
-UPLDRConstants.media_count = 0
+UPLDR_K.media_count = 0
 # Base dir for config and support files.
 #   Will use --config-file argument option
 #   If not, first try sys.prefix/etc folder (not operational)
 #   If not, then try Current Working Directory
-# UPLDRConstants.base_dir = os.path.join(sys.prefix, 'etc')
-UPLDRConstants.base_dir = os.path.dirname(sys.argv[0])
-UPLDRConstants.ini_file = os.path.join(UPLDRConstants.base_dir, "uploadr.ini")
-UPLDRConstants.err_file = os.path.join(UPLDRConstants.base_dir, "uploadr.err")
+# UPLDR_K.base_dir = os.path.join(sys.prefix, 'etc')
+UPLDR_K.base_dir = os.path.dirname(sys.argv[0])
+UPLDR_K.ini_file = os.path.join(UPLDR_K.base_dir, "uploadr.ini")
+UPLDR_K.err_file = os.path.join(UPLDR_K.base_dir, "uploadr.err")
 
 # CODING: Debug a series of control values
-logging.info('      base_dir:[%s]', UPLDRConstants.base_dir)
+logging.info('      base_dir:[%s]', UPLDR_K.base_dir)
 logging.info('           cwd:[%s]', os.getcwd())
 logging.info('    prefix/etc:[%s]', os.path.join(sys.prefix, 'etc'))
 logging.info('   sys.argv[0]:[%s]', os.path.dirname(sys.argv[0]))
-logging.info('      ini_file:[%s]', UPLDRConstants.ini_file)
-logging.info('      err_file:[%s]', UPLDRConstants.err_file)
+logging.info('      ini_file:[%s]', UPLDR_K.ini_file)
+logging.info('      err_file:[%s]', UPLDR_K.err_file)
 # -----------------------------------------------------------------------------
 
 # =============================================================================
@@ -465,7 +465,7 @@ NPR = NicePrint.NicePrint()
 # Main code
 #
 NPR.niceprint('----------- (V{!s}) Start -----------(Log:{!s})'
-              .format(UPLDRConstants.Version,
+              .format(UPLDR_K.Version,
                       MY_CFG.LOGGING_LEVEL))
 # Install exception handler
 sys.excepthook = my_excepthook
@@ -481,11 +481,11 @@ if __name__ == "__main__":
 
     # Argument --config-file overrides configuration filename.
     if PARSED_ARGS.config_file:
-        UPLDRConstants.ini_file = PARSED_ARGS.config_file
-        logging.info('UPLDRConstants.ini_file:[%s]',
-                     NPR.strunicodeout(UPLDRConstants.ini_file))
-        if not check_base_ini_file(UPLDRConstants.base_dir,
-                                   UPLDRConstants.ini_file):
+        UPLDR_K.ini_file = PARSED_ARGS.config_file
+        logging.info('UPLDR_K.ini_file:[%s]',
+                     NPR.strunicodeout(UPLDR_K.ini_file))
+        if not check_base_ini_file(UPLDR_K.base_dir,
+                                   UPLDR_K.ini_file):
             NPR.niceerror(caught=True,
                           caughtprefix='+++ ',
                           caughtcode='601',
@@ -494,8 +494,8 @@ if __name__ == "__main__":
                           useniceprint=True)
             sys.exit(2)
     else:
-        if not check_base_ini_file(UPLDRConstants.base_dir,
-                                   UPLDRConstants.ini_file):
+        if not check_base_ini_file(UPLDR_K.base_dir,
+                                   UPLDR_K.ini_file):
             NPR.niceerror(caught=True,
                           caughtprefix='+++ ',
                           caughtcode='602',
@@ -504,7 +504,7 @@ if __name__ == "__main__":
             sys.exit(2)
 
     # Source configuration from ini_file
-    MY_CFG.readconfig(UPLDRConstants.ini_file, ['Config'])
+    MY_CFG.readconfig(UPLDR_K.ini_file, ['Config'])
     if MY_CFG.processconfig():
         if MY_CFG.verifyconfig():
             pass
@@ -531,16 +531,16 @@ if __name__ == "__main__":
                 backupCount=MY_CFG.ROTATING_LOGGING_FILE_COUNT)
             ROTATING_LOGGING.setLevel(MY_CFG.ROTATING_LOGGING_LEVEL)
             ROTATING_LOGGING.setFormatter(logging.Formatter(
-                fmt='[' + str(UPLDRConstants.Run) + ']' +
+                fmt='[' + str(UPLDR_K.Run) + ']' +
                 '[%(asctime)s]:[%(processName)-11s]' +
                 '[%(levelname)-8s]:[%(name)s] %(message)s',
-                datefmt=UPLDRConstants.TimeFormat))
+                datefmt=UPLDR_K.TimeFormat))
             logging.getLogger().addHandler(ROTATING_LOGGING)
 
             logging.warning('----------- (V%s) Init Rotating '
                             '-----------(Log:%s)\n'
                             'Python version on this system: [%s]',
-                            UPLDRConstants.Version,
+                            UPLDR_K.Version,
                             MY_CFG.LOGGING_LEVEL,
                             sys.version)
 
@@ -579,8 +579,8 @@ if __name__ == "__main__":
     run_uploadr(PARSED_ARGS)
 
 NPR.niceprint('----------- (V{!s}) End -----------(Log:{!s})'
-              .format(UPLDRConstants.Version,
+              .format(UPLDR_K.Version,
                       MY_CFG.LOGGING_LEVEL))
 logging.warning('----------- (V%s) End -----------(Log:%s)',
-                UPLDRConstants.Version,
+                UPLDR_K.Version,
                 MY_CFG.LOGGING_LEVEL)

--- a/uploadr.py
+++ b/uploadr.py
@@ -516,22 +516,20 @@ if __name__ == "__main__":
     # Write one level more than console LOGGING level to err_file
     if MY_CFG.ROTATING_LOGGING:
         ROTATING_LOGGING = None
-        if not (UPLDRConstants.base_dir == ''
-                or os.path.isdir(UPLDRConstants.base_dir)):
+        if not os.path.isdir(os.dirname(MY_CFG.ROTATING_LOGGING_FILE)):
             NPR.niceerror(caught=True,
                           caughtprefix='+++ ',
                           caughtcode='603',
-                          caughtmsg='Invalid sys.argv ERR file '
-                          'prevents output to file.',
+                          caughtmsg='Invalid ROTATING_LOGGING config.',
                           useniceprint=True)
         else:
             # Define a rotating file Handler which writes DEBUG messages
             # or higher to err_file
             ROTATING_LOGGING = logging.handlers.RotatingFileHandler(
                 UPLDRConstants.err_file,
-                maxBytes=25*1024*1024,  # Max 25 MBytes per file size
-                backupCount=3)  # 3 rotating files
-            ROTATING_LOGGING.setLevel(logging.WARNING)
+                maxBytes=MY_CFG.ROTATING_LOGGING_FILE_SIZE,
+                backupCount=MY_CFG.ROTATING_LOGGING_FILE_COUNT)
+            ROTATING_LOGGING.setLevel(MY_CFG.ROTATING_LOGGING_LEVEL)
             ROTATING_LOGGING.setFormatter(logging.Formatter(
                 fmt='[' + str(UPLDRConstants.Run) + ']' +
                 '[%(asctime)s]:[%(processName)-11s]' +

--- a/uploadr.py
+++ b/uploadr.py
@@ -516,7 +516,7 @@ if __name__ == "__main__":
     # Write one level more than console LOGGING level to err_file
     if MY_CFG.ROTATING_LOGGING:
         ROTATING_LOGGING = None
-        if not os.path.isdir(os.dirname(MY_CFG.ROTATING_LOGGING_FILE)):
+        if not os.path.isdir(os.path.dirname(MY_CFG.ROTATING_LOGGING_FILE)):
             NPR.niceerror(caught=True,
                           caughtprefix='+++ ',
                           caughtcode='603',

--- a/uploadr.py
+++ b/uploadr.py
@@ -279,32 +279,34 @@ def run_uploadr(args):
     #
     #   myflick        = Class Uploadr (created in the Main code)
 
-    # Print/show arguments
-    if MY_CFG.LOGGING_LEVEL <= logging.INFO:
-        NPR.niceprint('Output for arguments(args):')
-        pprint.pprint(args)
-
-    if args.verbose:
-        NPR.niceprint('FILES_DIR: [{!s}]'
-                      .format(NPR.strunicodeout(MY_CFG.FILES_DIR)))
-
-    logging.warning('FILES_DIR: [%s]', NPR.strunicodeout(MY_CFG.FILES_DIR))
-
-    if MY_CFG.FILES_DIR == "":
-        NPR.niceprint('Please configure in the INI file [normally uploadr.ini]'
-                      ' the name of the folder [FILES_DIR] '
-                      'with media available to sync with Flickr.')
-        sys.exit(8)
-    else:
-        if not os.path.isdir(MY_CFG.FILES_DIR):
-            logging.critical('FILES_DIR: [%s] is not valid.',
-                             NPR.strunicodeout(MY_CFG.FILES_DIR))
-            NPR.niceprint('Please configure the name of an existant folder '
-                          'in the INI file [normally uploadr.ini] '
-                          'with media available to sync with Flickr. '
-                          'FILES_DIR: [{!s}] is not valid.'
+    def check_files_dir(self):
+        """ check_files_dir
+            
+            Confirms setting MYCFG.FILES_DIR is defined and a valid folder.
+            Exits from program otherwise.
+        """
+        logging.warning('FILES_DIR: [%s]', NPR.strunicodeout(MY_CFG.FILES_DIR))
+        if args.verbose:
+            NPR.niceprint('FILES_DIR: [{!s}]'
                           .format(NPR.strunicodeout(MY_CFG.FILES_DIR)))
+    
+        if MY_CFG.FILES_DIR == "":
+            NPR.niceprint('Please configure in the INI file [normally uploadr.ini]'
+                          ' the name of the folder [FILES_DIR] '
+                          'with media available to sync with Flickr.')
             sys.exit(8)
+        else:
+            if not os.path.isdir(MY_CFG.FILES_DIR):
+                logging.critical('FILES_DIR: [%s] is not valid.',
+                                 NPR.strunicodeout(MY_CFG.FILES_DIR))
+                NPR.niceprint('Please configure the name of an existant folder '
+                              'in the INI file [normally uploadr.ini] '
+                              'with media available to sync with Flickr. '
+                              'FILES_DIR: [{!s}] is not valid.'
+                              .format(NPR.strunicodeout(MY_CFG.FILES_DIR)))
+                sys.exit(8)
+
+    self.check_files_dir()
 
     if MY_CFG.FLICKR["api_key"] == "" or MY_CFG.FLICKR["secret"] == "":
         logging.critical('Please enter an API key and secret in the '
@@ -326,10 +328,11 @@ def run_uploadr(args):
     if args.daemon:
         # Will run in daemon mode every SLEEP_TIME seconds
         if myflick.check_token():
-            logging.warning('Will run in daemon mode every [%s] seconds',
+            logging.warning('Will run in daemon mode every [%s] seconds'
+                            'Make sure you have previously authenticated!',
                             MY_CFG.SLEEP_TIME)
-            logging.warning('Make sure you have previously authenticated!')
             NPR.niceprint('Will run in daemon mode every [{!s}] seconds'
+                          'Make sure you have previously authenticated!'
                           .format(MY_CFG.SLEEP_TIME))
             myflick.run()
         else:
@@ -458,8 +461,13 @@ NPR.niceprint('----------- (V{!s}) Start -----------(Log:{!s})'
 sys.excepthook = my_excepthook
 
 if __name__ == "__main__":
-    # Parse the argumens options
+    # Parse the arguments options
     PARSED_ARGS = parse_arguments()
+
+    # Print/show arguments
+    if MY_CFG.LOGGING_LEVEL <= logging.INFO:
+        NPR.niceprint('Output for arguments(args):')
+        pprint.pprint(PARSED_ARGS)
 
     # Argument --config-file overrides configuration filename.
     if PARSED_ARGS.config_file:
@@ -529,11 +537,6 @@ if __name__ == "__main__":
                             sys.version)
 
     # Update console/rotating logging level as per LOGGING_LEVEL from INI file
-    CONSOLE_LOGGING.setLevel(MY_CFG.LOGGING_LEVEL)
-    if MY_CFG.ROTATING_LOGGING:
-        ROTATING_LOGGING.setLevel(MY_CFG.LOGGING_LEVEL if
-                                  MY_CFG.LOGGING_LEVEL <= logging.DEBUG
-                                  else MY_CFG.LOGGING_LEVEL - 10)
     logging.warning('CONSOLE_LOGGING.setLevel=[%s] '
                     'ROTATING_LOGGING.setLevel/enabled?=[%s/%s] '
                     'MY_CFG.LOGGING_LEVEL=[%s]',
@@ -542,7 +545,13 @@ if __name__ == "__main__":
                     MY_CFG.LOGGING_LEVEL <= logging.DEBUG
                     else MY_CFG.LOGGING_LEVEL - 10,
                     MY_CFG.ROTATING_LOGGING,
-                    MY_CFG.LOGGING_LEVEL)
+                    MY_CFG.LOGGING_LEVEL)    
+    CONSOLE_LOGGING.setLevel(MY_CFG.LOGGING_LEVEL)
+    if MY_CFG.ROTATING_LOGGING:
+        ROTATING_LOGGING.setLevel(MY_CFG.LOGGING_LEVEL if
+                                  MY_CFG.LOGGING_LEVEL <= logging.DEBUG
+                                  else MY_CFG.LOGGING_LEVEL - 10)
+
 
     if MY_CFG.LOGGING_LEVEL <= logging.INFO:
         NPR.niceprint('Output for FLICKR Configuration:')

--- a/uploadr.py
+++ b/uploadr.py
@@ -509,7 +509,7 @@ if __name__ == "__main__":
         # or higher to err_file
         ROTATING_LOGGING = logging.handlers.RotatingFileHandler(
             UPLDRConstants.err_file,
-            maxBytes=25*1024*1024,  # Mas 25 MBytes per file size
+            maxBytes=25*1024*1024,  # Max 25 MBytes per file size
             backupCount=3)  # 3 rotating files
         ROTATING_LOGGING.setLevel(logging.WARNING)
         ROTATING_LOGGING.setFormatter(logging.Formatter(

--- a/uploadr.py
+++ b/uploadr.py
@@ -193,8 +193,8 @@ def parse_arguments():
     # used in printStat function
     igrpparser.add_argument('-l', '--list-photos-not-in-set',
                             metavar='N', type=int,
-                            help='List as many as N photos not in set. '
-                                 'Maximum listed photos is 500.')
+                            help='List as many as N photos (9)with tags) '
+                                 'not in set. Maximum listed photos is 500.')
     # finds duplicated images (based on checksum, titlename, setName) in Flickr
     igrpparser.add_argument('-z', '--search-for-duplicates',
                             action='store_true',

--- a/uploadr.py
+++ b/uploadr.py
@@ -279,9 +279,9 @@ def run_uploadr(args):
     #
     #   myflick        = Class Uploadr (created in the Main code)
 
-    def check_files_dir(self):
+    def check_files_dir():
         """ check_files_dir
-            
+
             Confirms setting MYCFG.FILES_DIR is defined and a valid folder.
             Exits from program otherwise.
         """
@@ -289,9 +289,9 @@ def run_uploadr(args):
         if args.verbose:
             NPR.niceprint('FILES_DIR: [{!s}]'
                           .format(NPR.strunicodeout(MY_CFG.FILES_DIR)))
-    
+
         if MY_CFG.FILES_DIR == "":
-            NPR.niceprint('Please configure in the INI file [normally uploadr.ini]'
+            NPR.niceprint('Please configure in INI file [normally uploadr.ini]'
                           ' the name of the folder [FILES_DIR] '
                           'with media available to sync with Flickr.')
             sys.exit(8)
@@ -299,14 +299,14 @@ def run_uploadr(args):
             if not os.path.isdir(MY_CFG.FILES_DIR):
                 logging.critical('FILES_DIR: [%s] is not valid.',
                                  NPR.strunicodeout(MY_CFG.FILES_DIR))
-                NPR.niceprint('Please configure the name of an existant folder '
-                              'in the INI file [normally uploadr.ini] '
+                NPR.niceprint('Please configure the name of an existant folder'
+                              ' in INI file [normally uploadr.ini] '
                               'with media available to sync with Flickr. '
                               'FILES_DIR: [{!s}] is not valid.'
                               .format(NPR.strunicodeout(MY_CFG.FILES_DIR)))
                 sys.exit(8)
 
-    self.check_files_dir()
+    check_files_dir()
 
     if MY_CFG.FLICKR["api_key"] == "" or MY_CFG.FLICKR["secret"] == "":
         logging.critical('Please enter an API key and secret in the '
@@ -545,13 +545,12 @@ if __name__ == "__main__":
                     MY_CFG.LOGGING_LEVEL <= logging.DEBUG
                     else MY_CFG.LOGGING_LEVEL - 10,
                     MY_CFG.ROTATING_LOGGING,
-                    MY_CFG.LOGGING_LEVEL)    
+                    MY_CFG.LOGGING_LEVEL)
     CONSOLE_LOGGING.setLevel(MY_CFG.LOGGING_LEVEL)
     if MY_CFG.ROTATING_LOGGING:
         ROTATING_LOGGING.setLevel(MY_CFG.LOGGING_LEVEL if
                                   MY_CFG.LOGGING_LEVEL <= logging.DEBUG
                                   else MY_CFG.LOGGING_LEVEL - 10)
-
 
     if MY_CFG.LOGGING_LEVEL <= logging.INFO:
         NPR.niceprint('Output for FLICKR Configuration:')

--- a/uploadr.py
+++ b/uploadr.py
@@ -435,10 +435,12 @@ def check_base_ini_file(base_dir, ini_file):
 # UPLDRConstants = UPLDRConstantsClass.UPLDRConstants()
 UPLDR_K.media_count = 0
 # Base dir for config and support files.
-#   Will use --config-file argument option
-#   If not, first try sys.prefix/etc folder (not operational)
-#   If not, then try Current Working Directory
+#   Will use --config-file argument option [after PARSED_ARGS]
+#   If not, first try sys.prefix/etc folder [not operational]
+#   If not, then try Current Working Directory (getcwd) [not operational]
+#   If not, then try folder where uploadr.py is located (dirname(sys.argv[0]))
 # UPLDR_K.base_dir = os.path.join(sys.prefix, 'etc')
+# UPLDR_K.base_dir = os.getcwd()
 UPLDR_K.base_dir = os.path.dirname(sys.argv[0])
 UPLDR_K.ini_file = os.path.join(UPLDR_K.base_dir, "uploadr.ini")
 UPLDR_K.err_file = os.path.join(UPLDR_K.base_dir, "uploadr.err")

--- a/uploadr.py
+++ b/uploadr.py
@@ -316,9 +316,10 @@ def run_uploadr(args):
         if MY_CFG.FLICKR["api_key"] == "" or MY_CFG.FLICKR["secret"] == "":
             logging.critical('Please enter an API key and secret in the '
                              'configuration '
-                             'script file, normaly uploadr.ini (see README).')
-            NPR.niceprint('Please enter an API key and secret in the configuration'
-                          ' script file, normaly uploadr.ini (see README).')
+                             'file [normaly uploadr.ini] (see README).')
+            NPR.niceprint('Please enter an API key and secret in the '
+                          'configuration'
+                          'file [normaly uploadr.ini] (see README).')
             sys.exit(9)
 
     # Initial checks

--- a/uploadr.py
+++ b/uploadr.py
@@ -485,37 +485,6 @@ if __name__ == "__main__":
                           useniceprint=True)
             sys.exit(2)
 
-    # Write one level more than console LOGGING level to err_file
-    ROTATING_LOGGING = None
-    if not (UPLDRConstants.base_dir == ''
-            or os.path.isdir(UPLDRConstants.base_dir)):
-        NPR.niceerror(caught=True,
-                      caughtprefix='+++ ',
-                      caughtcode='603',
-                      caughtmsg='Invalid sys.argv ERR file '
-                      'prevents output to file.',
-                      useniceprint=True)
-    else:
-        # Define a rotating file Handler which writes DEBUG messages
-        # or higher to err_file
-        ROTATING_LOGGING = logging.handlers.RotatingFileHandler(
-            UPLDRConstants.err_file,
-            maxBytes=25*1024*1024,  # Max 25 MBytes per file size
-            backupCount=3)  # 3 rotating files
-        ROTATING_LOGGING.setLevel(logging.WARNING)
-        ROTATING_LOGGING.setFormatter(logging.Formatter(
-            fmt='[' + str(UPLDRConstants.Run) + ']' +
-            '[%(asctime)s]:[%(processName)-11s]' +
-            '[%(levelname)-8s]:[%(name)s] %(message)s',
-            datefmt=UPLDRConstants.TimeFormat))
-        logging.getLogger().addHandler(ROTATING_LOGGING)
-
-        logging.warning('----------- (V%s) Init Rotating -----------(Log:%s)\n'
-                        'Python version on this system: [%s]',
-                        UPLDRConstants.Version,
-                        MY_CFG.LOGGING_LEVEL,
-                        sys.version)
-
     # Source configuration from ini_file
     MY_CFG.readconfig(UPLDRConstants.ini_file, ['Config'])
     if MY_CFG.processconfig():
@@ -526,18 +495,52 @@ if __name__ == "__main__":
     else:
         raise ValueError('No config file found or incorrect config!')
 
+    # Write one level more than console LOGGING level to err_file
+    if MY_CFG.ROTATING_LOGGING:
+        ROTATING_LOGGING = None
+        if not (UPLDRConstants.base_dir == ''
+                or os.path.isdir(UPLDRConstants.base_dir)):
+            NPR.niceerror(caught=True,
+                          caughtprefix='+++ ',
+                          caughtcode='603',
+                          caughtmsg='Invalid sys.argv ERR file '
+                          'prevents output to file.',
+                          useniceprint=True)
+        else:
+            # Define a rotating file Handler which writes DEBUG messages
+            # or higher to err_file
+            ROTATING_LOGGING = logging.handlers.RotatingFileHandler(
+                UPLDRConstants.err_file,
+                maxBytes=25*1024*1024,  # Max 25 MBytes per file size
+                backupCount=3)  # 3 rotating files
+            ROTATING_LOGGING.setLevel(logging.WARNING)
+            ROTATING_LOGGING.setFormatter(logging.Formatter(
+                fmt='[' + str(UPLDRConstants.Run) + ']' +
+                '[%(asctime)s]:[%(processName)-11s]' +
+                '[%(levelname)-8s]:[%(name)s] %(message)s',
+                datefmt=UPLDRConstants.TimeFormat))
+            logging.getLogger().addHandler(ROTATING_LOGGING)
+
+            logging.warning('----------- (V%s) Init Rotating -----------(Log:%s)\n'
+                            'Python version on this system: [%s]',
+                            UPLDRConstants.Version,
+                            MY_CFG.LOGGING_LEVEL,
+                            sys.version)
+
     # Update console/rotating logging level as per LOGGING_LEVEL from INI file
     CONSOLE_LOGGING.setLevel(MY_CFG.LOGGING_LEVEL)
-    ROTATING_LOGGING.setLevel(MY_CFG.LOGGING_LEVEL if
-                              MY_CFG.LOGGING_LEVEL <= logging.DEBUG
-                              else MY_CFG.LOGGING_LEVEL - 10)
+    if MY_CFG.ROTATING_LOGGING:
+        ROTATING_LOGGING.setLevel(MY_CFG.LOGGING_LEVEL if
+                                  MY_CFG.LOGGING_LEVEL <= logging.DEBUG
+                                  else MY_CFG.LOGGING_LEVEL - 10)
     logging.warning('CONSOLE_LOGGING.setLevel=[%s] '
-                    'ROTATING_LOGGING.setLevel=[%s] '
+                    'ROTATING_LOGGING.setLevel/enabled?=[%s/%s] '
                     'MY_CFG.LOGGING_LEVEL=[%s]',
                     MY_CFG.LOGGING_LEVEL,
                     MY_CFG.LOGGING_LEVEL if
                     MY_CFG.LOGGING_LEVEL <= logging.DEBUG
                     else MY_CFG.LOGGING_LEVEL - 10,
+                    MY_CFG.ROTATING_LOGGING,
                     MY_CFG.LOGGING_LEVEL)
 
     if MY_CFG.LOGGING_LEVEL <= logging.INFO:

--- a/uploadr.py
+++ b/uploadr.py
@@ -341,7 +341,7 @@ def run_uploadr(args):
 
     if args.authenticate:
         NPR.niceprint('Checking if token is available... '
-                      'if not will authenticate')
+                      'if not, will authenticate')
         if not myflick.check_token():
             # authenticate sys.exits in case of failure
             myflick.authenticate()

--- a/uploadr.py
+++ b/uploadr.py
@@ -526,7 +526,7 @@ if __name__ == "__main__":
             # Define a rotating file Handler which writes DEBUG messages
             # or higher to err_file
             ROTATING_LOGGING = logging.handlers.RotatingFileHandler(
-                UPLDRConstants.err_file,
+                MY_CFG.ROTATING_LOGGING_PATH,
                 maxBytes=MY_CFG.ROTATING_LOGGING_FILE_SIZE,
                 backupCount=MY_CFG.ROTATING_LOGGING_FILE_COUNT)
             ROTATING_LOGGING.setLevel(MY_CFG.ROTATING_LOGGING_LEVEL)

--- a/uploadr.py
+++ b/uploadr.py
@@ -306,21 +306,30 @@ def run_uploadr(args):
                               .format(NPR.strunicodeout(MY_CFG.FILES_DIR)))
                 sys.exit(8)
 
-    check_files_dir()
+    def check_flickr_key_secret():
+        """ def check_flickr_key_secret():
 
-    if MY_CFG.FLICKR["api_key"] == "" or MY_CFG.FLICKR["secret"] == "":
-        logging.critical('Please enter an API key and secret in the '
-                         'configuration '
-                         'script file, normaly uploadr.ini (see README).')
-        NPR.niceprint('Please enter an API key and secret in the configuration'
-                      ' script file, normaly uploadr.ini (see README).')
-        sys.exit(9)
+            Confirms the configuration for api_key and secret is defined.
+            Exits from program otherwise.
+        """
+
+        if MY_CFG.FLICKR["api_key"] == "" or MY_CFG.FLICKR["secret"] == "":
+            logging.critical('Please enter an API key and secret in the '
+                             'configuration '
+                             'script file, normaly uploadr.ini (see README).')
+            NPR.niceprint('Please enter an API key and secret in the configuration'
+                          ' script file, normaly uploadr.ini (see README).')
+            sys.exit(9)
+
+    # Initial checks
+    check_files_dir()
+    check_flickr_key_secret()
 
     # Instantiate class Uploadr. getCachedToken is called on __init__
     logging.debug('Instantiating the Main class myflick = Uploadr()')
     myflick = FlickrUploadr.Uploadr(MY_CFG, args)
 
-    # Setup the database
+    # Setup the database. Clean badfiles entries if asked
     myflick.setupDB()
     if args.clean_bad_files:
         myflick.cleanDBbadfiles()

--- a/uploadr.py
+++ b/uploadr.py
@@ -193,7 +193,7 @@ def parse_arguments():
     # used in printStat function
     igrpparser.add_argument('-l', '--list-photos-not-in-set',
                             metavar='N', type=int,
-                            help='List as many as N photos (9)with tags) '
+                            help='List as many as N photos (with tags) '
                                  'not in set. Maximum listed photos is 500.')
     # finds duplicated images (based on checksum, titlename, setName) in Flickr
     igrpparser.add_argument('-z', '--search-for-duplicates',

--- a/uploadr.py
+++ b/uploadr.py
@@ -516,7 +516,7 @@ if __name__ == "__main__":
     # Write one level more than console LOGGING level to err_file
     if MY_CFG.ROTATING_LOGGING:
         ROTATING_LOGGING = None
-        if not os.path.isdir(os.path.dirname(MY_CFG.ROTATING_LOGGING_FILE)):
+        if not os.path.isdir(os.path.dirname(MY_CFG.ROTATING_LOGGING_PATH)):
             NPR.niceerror(caught=True,
                           caughtprefix='+++ ',
                           caughtcode='603',

--- a/uploadr.py
+++ b/uploadr.py
@@ -549,9 +549,7 @@ if __name__ == "__main__":
                     'ROTATING_LOGGING.setLevel/enabled?=[%s/%s] '
                     'MY_CFG.LOGGING_LEVEL=[%s]',
                     MY_CFG.LOGGING_LEVEL,
-                    MY_CFG.LOGGING_LEVEL if
-                    MY_CFG.LOGGING_LEVEL <= logging.DEBUG
-                    else MY_CFG.LOGGING_LEVEL - 10,
+                    MY_CFG.ROTATING_LOGGING_LEVEL,
                     MY_CFG.ROTATING_LOGGING,
                     MY_CFG.LOGGING_LEVEL)
     CONSOLE_LOGGING.setLevel(MY_CFG.LOGGING_LEVEL)


### PR DESCRIPTION
## Fixes/Features
- Several under the hood code refactoring, pylint3 check and more.
- Fix: #66 fix Flickr error: "ValueError: invalid literal for int() with base 10"
- Feature: #60 Initial authentication option (-a)
- Internal improvement: #64 Isolate and wrap around retry and try/except sequence to flickrapi function calls
- Feature: #68 Option to have Rotating Error Log written to files to keep size under control.
- Setup (**optional**):
   - You can run install with command:
`python3 setup.py install --prefix=~/apps/Python`
   - You can run installcfg to copy config files (.ini and .cron) to a designated folder with command:
`python3 setup.py installcfg --folder ~/apps/flickr-uploader`
- From v2.7.6 `uploadr.ini` configuration is searched from:
   -  `--config-file` argument
   - from the sys.argv[0] path (compatible with previous versions)

## Questions & Answers
- **Note that uploadr.ini definition for path search** of DB_PATH, LOCK_PATH, TOKEN_CACHE and TOKEN_PATH still uses sys.argv[0] location as a basis.
- (to be) Updated installation notes on Readme.

## Output Messages
- Adjustments on output and logging messages.
- Feature: #68 Option to have Rotating Error Log written to files to keep size under control.
   - New set of options related to Rotating Error Logging added to uploadr.ini:
```
################################################################################
#   Output logging information into a rotating set of log file(s).
#       ROTATING_LOGGING to Enable/Disable
#       ROTATING_LOGGING_PATH location of folder/main logging filename
#       ROTATING_LOGGING_FILE_SIZE for maximum file size of each log file
#       ROTATING_LOGGING_FILE_COUNT for maximum count of old log files to keep
#       ROTATING_LOGGING_LEVEL Level Logging 
#           Check LOGGING_LEVEL setting for options.
#           Normally set ROTATING_LOGGING_LEVELto lower than LOGGING_LEVEL
################################################################################
ROTATING_LOGGING = False
ROTATING_LOGGING_PATH = os.path.join(os.path.dirname(sys.argv[0]), "logs", "uploadr.err")
ROTATING_LOGGING_FILE_SIZE = 25*1024*1024  # 25 MBytes
ROTATING_LOGGING_FILE_COUNT = 3
ROTATING_LOGGING_LEVEL = 30
```

## Environment and Coding
- Python 2.7 + 3.6 compatibility: use of "# noqa" as applicable
- autopep8, PEP8, flakes and pylint3 (not all!) adjustments
- pytest --flakes & pytest --doctest-modules
- Runs several unittests
- setup.py (**optional use**)
- setup.py installcfg (**optional use**)